### PR TITLE
Add option to keep reads as paired & stranded 

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use crate::dna_string::{DnaString, PackedDnaStringSet};
 use crate::graph::{BaseGraph, DebruijnGraph};
-use crate::Dir;
+use crate::{Dir, PROGRESS_STYLE};
 use crate::Exts;
 use crate::Kmer;
 use crate::Vmer;
@@ -875,7 +875,7 @@ impl<K: Kmer +  Send + Sync, D: Clone + Debug + Send + Sync, S: CompressionSpec<
         }
 
         let pb = ProgressBar::new(n_kmers as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "compressing graph"));
 
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -74,12 +74,12 @@ pub fn bucket<K: Kmer>(kmer: K) -> usize {
 /// 
 /// ```
 /// use debruijn::summarizer::{SampleInfo, SummaryConfig, TagsCountsData, StatTest, GroupFrac};
-/// use debruijn::reads::Reads;
+/// use debruijn::reads::{Reads, ReadsPaired, Stranded};
 /// use debruijn::filter::filter_kmers_parallel;
 /// use debruijn::kmer::Kmer16;
 /// use debruijn::Exts;
 /// 
-/// let mut seqs = Reads::new();
+/// let mut seqs = Reads::new(Stranded::Unstranded);
 /// seqs.add_from_bytes("ACCGATCATATATTTTCGGGGCTAGGCGAAGCGATCTTATCGAGC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGATCGAGCATGCTCAGCTGACGTGACTGACGTAGCTATCTTTTCGTAGCTAC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGAGTTTGCGACTCGAGGCTATCTAGCTAGCTASGCTCTCGACTAGCTGACTTACGACGACTACG".as_bytes(), Exts::empty(), 2u8);
@@ -104,9 +104,8 @@ pub fn bucket<K: Kmer>(kmer: K) -> usize {
 /// );
 ///    
 /// let (hashed_kmers, _) = filter_kmers_parallel::<Kmer16, TagsCountsData>(
-///     &seqs,
+///     &ReadsPaired::Unpaired { reads: seqs },
 ///     &summary_config,
-///     false,
 ///     false,
 ///     10,
 ///     false,
@@ -229,6 +228,7 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
             size = capacity;
         }
     }   
+    bucket_ranges.push(start_bucket..BUCKETS);
 
     debug!("bucket_ranges: {:?}, len br: {}", bucket_ranges, bucket_ranges.len());
     assert!(bucket_ranges[bucket_ranges.len() - 1].end >= BUCKETS);
@@ -490,12 +490,12 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 /// 
 /// ```
 /// use debruijn::summarizer::{SampleInfo, SummaryConfig, TagsCountsData, StatTest, GroupFrac};
-/// use debruijn::reads::Reads;
+/// use debruijn::reads::{Reads, ReadsPaired, Stranded};
 /// use debruijn::filter::filter_kmers;
 /// use debruijn::kmer::Kmer16;
 /// use debruijn::Exts;
 /// 
-/// let mut seqs = Reads::new();
+/// let mut seqs = Reads::new(Stranded::Unstranded);
 /// seqs.add_from_bytes("ACCGATCATATATTTTCGGGGCTAGGCGAAGCGATCTTATCGAGC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGATCGAGCATGCTCAGCTGACGTGACTGACGTAGCTATCTTTTCGTAGCTAC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGAGTTTGCGACTCGAGGCTATCTAGCTAGCTASGCTCTCGACTAGCTGACTTACGACGACTACG".as_bytes(), Exts::empty(), 2u8);
@@ -520,9 +520,8 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 /// );
 ///    
 /// let (hashed_kmers, _) = filter_kmers::<TagsCountsData, Kmer16, _>(
-///     &seqs,
+///     &ReadsPaired::Unpaired { reads: seqs },
 ///     &summary_config,
-///     false,
 ///     false,
 ///     10,
 ///    false,
@@ -617,6 +616,7 @@ where
             size = *capacity;
         }
     }
+    bucket_ranges.push(start_bucket..BUCKETS);
 
     debug!("bucket ranges: {:?}", bucket_ranges);
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -41,6 +41,7 @@ use crate::dna_string::{DnaString, DnaStringSlice, PackedDnaStringSet};
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
 use crate::BUF;
+use crate::PROGRESS_STYLE;
 use crate::{Dir, Exts, Kmer, Mer, Vmer};
 
 /// A compressed DeBruijn graph carrying auxiliary data on each node of type `D`.
@@ -717,7 +718,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let mut f = BufWriter::with_capacity(BUF, File::create(path).expect("error creating dot file"));
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT file"));
 
         writeln!(&mut f, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
@@ -774,7 +775,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         } 
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT files"));
     
         parallel_ranges.into_par_iter().enumerate().for_each(|(i, range)| {
@@ -794,7 +795,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(&mut out_file, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
 
         let pb = ProgressBar::new(files.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "combining files"));
 
         for file in files.iter().progress_with(pb) {
@@ -836,7 +837,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let mut f = BufWriter::with_capacity(BUF, File::create(path).expect("error creating dot file"));
 
         let pb = ProgressBar::new(nodes.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT file"));
 
         writeln!(&mut f, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
@@ -925,7 +926,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let dummy_opt: Option<&DummyFn<K, D>> = None;
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
 
         for i in (0..self.len()).progress_with(pb) {
@@ -948,7 +949,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(wtr, "H\tVN:Z:debruijn-rs")?;
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
 
         for i in (0..self.len()).progress_with(pb) {
@@ -998,7 +999,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         } 
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
         
         
@@ -1021,7 +1022,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(out_file, "H\tVN:Z:debruijn-rs")?;
 
         let pb = ProgressBar::new(files.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "combining files"));
 
         for file in files.iter() {
@@ -1049,7 +1050,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(wtr, "H\tVN:Z:debruijn-rs")?;
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
 
         for i in nodes.into_iter().progress_with(pb) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod colors;
 const BUF: usize = 64*1024;
 const BUCKETS: usize = 256;
 const ALPHABET_SIZE: usize = 4;
+const PROGRESS_STYLE: &str = "{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})";
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod bitops_avx2;

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -381,14 +381,16 @@ impl<D: Clone + Copy + Debug> Display for Reads<D> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ReadsPaired<D> {
     Unpaired { reads: Reads<D> },
-    Paired { r1: Reads<D>, r2: Reads<D> }
+    Paired { r1: Reads<D>, r2: Reads<D> },
+    Combined {r1: Reads<D>, r2: Reads<D>, unpaired: Reads<D>}
 }
 
 impl<D: Clone + Copy> ReadsPaired<D> {
     pub fn iterable(&self) -> Vec<&Reads<D>> {
         match self {
             Self::Unpaired { reads  } => vec![reads],
-            Self::Paired { r1, r2 } => vec![r1, r2]
+            Self::Paired { r1, r2 } => vec![r1, r2],
+            Self::Combined { r1, r2, unpaired } => vec![r1, r2, unpaired],
         }
     }
 
@@ -396,6 +398,7 @@ impl<D: Clone + Copy> ReadsPaired<D> {
         match self {
             Self::Unpaired { reads  } => reads.n_reads(),
             Self::Paired { r1, r2 } => r1.n_reads() + r2.n_reads(),
+            Self::Combined { r1, r2, unpaired } => r1.n_reads() + r2.n_reads() + unpaired.n_reads(),
         }
     }
 }

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -23,6 +23,7 @@ pub enum Stranded {
 /// * `exts`: `Vec` with one Exts for each sequence
 /// * `data`: `Vec` with data for each sequence
 /// * `len`: length of all sequences together
+/// * `stranded`: [`Stranded`] conveying the strandedness and direction of the reads
 #[derive(Ord, PartialOrd, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
 pub struct Reads<D> {
     storage: Vec<u64>,
@@ -377,6 +378,7 @@ impl<D: Clone + Copy + Debug> Display for Reads<D> {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ReadsPaired<D> {
     Unpaired { reads: Reads<D> },
     Paired { r1: Reads<D>, r2: Reads<D> }

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -413,6 +413,24 @@ impl<D: Clone + Copy> ReadsPaired<D> {
             Self::Combined { r1, r2, unpaired } => r1.mem() + r2.mem() + unpaired.mem(),
         }
     }
+
+    // TODO complex logic, add test!!!
+    // TODO add assertions to identify problems with read formatting
+    /// transform a tuple of two paired [`Reads`] and one unpaired [`Reads`] into a `ReadsPaired`
+    /// depending on the contents of the [`Reads`]
+    pub fn from_reads(reads: (Reads<D>, Reads<D>, Reads<D>)) -> Self {
+        if (reads.0.n_reads() + reads.1.n_reads() + reads.2.n_reads()) == 0 {
+            panic!("Error: files empty, no reads to process")
+        } else if (reads.0.n_reads() + reads.1.n_reads()) == 0 && reads.2.n_reads() > 0 {
+            ReadsPaired::Unpaired { reads: reads.2 }
+        } else if reads.0.n_reads() > 0 && reads.0.n_reads() == reads.0.n_reads() && reads.2.n_reads() == 0 {
+            ReadsPaired::Paired { r1: reads.0, r2: reads.1 }
+        } else if reads.0.n_reads() > 0 && reads.0.n_reads() == reads.0.n_reads() && reads.2.n_reads() > 0 {
+            ReadsPaired::Combined { r1: reads.0, r2: reads.1, unpaired: reads.2 }
+        } else {
+            panic!("error in transforming reads into ReadsPaired")
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -404,6 +404,15 @@ impl<D: Clone + Copy> ReadsPaired<D> {
             Self::Combined { r1, r2, unpaired } => r1.n_reads() + r2.n_reads() + unpaired.n_reads(),
         }
     }
+
+    pub fn mem(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::Unpaired { reads } => reads.mem(),
+            Self::Paired { r1, r2 } => r1.mem() + r2.mem(),
+            Self::Combined { r1, r2, unpaired } => r1.mem() + r2.mem() + unpaired.mem(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -380,6 +380,7 @@ impl<D: Clone + Copy + Debug> Display for Reads<D> {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ReadsPaired<D> {
+    Empty,
     Unpaired { reads: Reads<D> },
     Paired { r1: Reads<D>, r2: Reads<D> },
     Combined {r1: Reads<D>, r2: Reads<D>, unpaired: Reads<D>}
@@ -388,6 +389,7 @@ pub enum ReadsPaired<D> {
 impl<D: Clone + Copy> ReadsPaired<D> {
     pub fn iterable(&self) -> Vec<&Reads<D>> {
         match self {
+            Self::Empty => vec![],
             Self::Unpaired { reads  } => vec![reads],
             Self::Paired { r1, r2 } => vec![r1, r2],
             Self::Combined { r1, r2, unpaired } => vec![r1, r2, unpaired],
@@ -396,6 +398,7 @@ impl<D: Clone + Copy> ReadsPaired<D> {
 
     pub fn n_reads(&self) -> usize {
         match self {
+            Self::Empty => 0,
             Self::Unpaired { reads  } => reads.n_reads(),
             Self::Paired { r1, r2 } => r1.n_reads() + r2.n_reads(),
             Self::Combined { r1, r2, unpaired } => r1.n_reads() + r2.n_reads() + unpaired.n_reads(),


### PR DESCRIPTION
- add new `ReadsPaired` to store paired reads in
- add `Stranded` to `Reads` to store strandedness
- adapt `filter_kmers` and `filter_kmers_parallel` to respect strandedness of reads