### PR TITLE
Fix disconnected edges & add paired/stranded reads

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use crate::dna_string::{DnaString, PackedDnaStringSet};
 use crate::graph::{BaseGraph, DebruijnGraph};
-use crate::Dir;
+use crate::{Dir, PROGRESS_STYLE};
 use crate::Exts;
 use crate::Kmer;
 use crate::Vmer;
@@ -875,7 +875,7 @@ impl<K: Kmer +  Send + Sync, D: Clone + Debug + Send + Sync, S: CompressionSpec<
         }
 
         let pb = ProgressBar::new(n_kmers as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "compressing graph"));
 
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -367,9 +367,9 @@ where
             }
         }
 
-        // We will have some hanging exts due to
+        // We will have some hanging exts due to removed nodes
         let mut dbg = graph.finish();
-        dbg.fix_exts(None); // ????
+        dbg.fix_exts(None); 
         debug_assert!(dbg.is_compressed(compression).is_none());
         dbg
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,7 +2,6 @@
 
 //! Methods for converting sequences into kmers, filtering observed kmers before De Bruijn graph construction, and summarizing 'color' annotations.
 
-use core::f32;
 use std::fmt::Debug;
 use std::mem;
 use std::ops::Range;
@@ -17,11 +16,11 @@ use indicatif::ProgressIterator;
 use indicatif::ProgressStyle;
 use itertools::Itertools;
 use log::debug;
-use num_traits::Pow;
 use rayon::current_num_threads;
 use rayon::prelude::*;
 
-use crate::reads::Reads;
+use crate::reads::ReadsPaired;
+use crate::reads::Stranded;
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
 use crate::Dir;
@@ -29,6 +28,7 @@ use crate::Exts;
 use crate::Kmer;
 use crate::Vmer;
 use crate::BUCKETS;
+use crate::PROGRESS_STYLE;
 
 // FIXME does not work with k < 4
 pub fn bucket<K: Kmer>(kmer: K) -> usize {
@@ -38,30 +38,50 @@ pub fn bucket<K: Kmer>(kmer: K) -> usize {
         | (kmer.get(3) as usize)
 }
 
-fn lin_quant(p: f32, m: f32, b: f32) -> f32 {
-    ((b * b + 2. * m * p).sqrt() - b) / m
+fn bucket_flip<K: Kmer>(kmer: K, stranded: Stranded) -> usize {
+    // if not stranded choose lexiographically lesser of kmer and rc of kmer
+    // if forward, use original kmer
+    // if reverse, use rc of kmer
+    let min_kmer = match stranded {
+        Stranded::Unstranded => {
+            let (min_kmer, _) = kmer.min_rc_flip();
+            min_kmer
+        },
+        Stranded::Forward => kmer,
+        Stranded::Reverse => kmer.rc(),
+    };
+
+    // calculate which bucket this kmer belongs to
+    if K::k() > 3 { bucket(min_kmer) } else { min_kmer.to_u64() as usize }
+    //let bucket = bucket(min_kmer);
 }
 
-fn lin_dist_range(buckets: usize, slices: usize) -> Vec<Range<usize>> {
-    let b: f32 = 2f32/buckets as f32;
-    let m: f32 = - 2f32/(buckets as f32).pow(2);
+fn bucket_ext_flip<K: Kmer>(kmer: K, exts: Exts, stranded: Stranded, bucket_range: Range<usize>) ->Option<(K, Exts, usize)> {
+    // if not stranded choose lexiographically lesser of kmer and rc of kmer
+    // if forward, use original kmer
+    // if reverse, use rc of kmer
+    let (min_kmer, flip_exts) = match stranded {
+        Stranded::Unstranded => {
+            let (min_kmer, flip) = kmer.min_rc_flip();
+            let flip_exts = if flip { exts.rc() } else { exts };
+            (min_kmer, flip_exts)
+        },
+        Stranded::Forward => (kmer, exts),
+        Stranded::Reverse => (kmer.rc(), exts.rc()),
+    };
 
-    let mut bucket_ranges_lin: Vec<std::ops::Range<usize>> = Vec::with_capacity(if slices < buckets {slices} else {buckets});
+    // calculate which bucket this kmer belongs to
+    let bucket = if K::k() > 3 { bucket(min_kmer) } else { min_kmer.to_u64() as usize };
+    //let bucket = bucket(min_kmer);
+    // check if bucket is in current range and if so, push kmer to bucket
+    let in_range = bucket >= bucket_range.start && bucket < bucket_range.end;
 
-    for i in 1..=slices {
-        // calculate lower and upper bound with Quantile function of linear probability distribution
-        let lbound = lin_quant((i as f32 - 1.)/slices as f32, m, b) as usize;
-        let ubound = lin_quant((i as f32)/slices as f32, m, b) as usize;
-
-        // if upper bound is above no of buckets (256), reduce to no of buckets
-        let ubound: usize = if ubound > buckets { buckets } else { ubound };
-        if ubound > lbound && lbound < buckets { bucket_ranges_lin.push(lbound..ubound) };
+    if in_range {
+        Some((min_kmer, flip_exts, bucket))
+    } else {
+        None
     }
-
-    bucket_ranges_lin
 }
-
-
 
 /// Process DNA sequences into kmers and determine the set of valid kmers,
 /// their extensions, and summarize associated label/'color' data. The input
@@ -101,12 +121,12 @@ fn lin_dist_range(buckets: usize, slices: usize) -> Vec<Range<usize>> {
 /// 
 /// ```
 /// use debruijn::summarizer::{SampleInfo, SummaryConfig, TagsCountsData, StatTest, GroupFrac};
-/// use debruijn::reads::Reads;
+/// use debruijn::reads::{Reads, ReadsPaired, Stranded};
 /// use debruijn::filter::filter_kmers_parallel;
 /// use debruijn::kmer::Kmer16;
 /// use debruijn::Exts;
 /// 
-/// let mut seqs = Reads::new();
+/// let mut seqs = Reads::new(Stranded::Unstranded);
 /// seqs.add_from_bytes("ACCGATCATATATTTTCGGGGCTAGGCGAAGCGATCTTATCGAGC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGATCGAGCATGCTCAGCTGACGTGACTGACGTAGCTATCTTTTCGTAGCTAC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGAGTTTGCGACTCGAGGCTATCTAGCTAGCTASGCTCTCGACTAGCTGACTTACGACGACTACG".as_bytes(), Exts::empty(), 2u8);
@@ -131,9 +151,8 @@ fn lin_dist_range(buckets: usize, slices: usize) -> Vec<Range<usize>> {
 /// );
 ///    
 /// let (hashed_kmers, _) = filter_kmers_parallel::<Kmer16, TagsCountsData>(
-///     &seqs,
+///     &ReadsPaired::Unpaired { reads: seqs },
 ///     &summary_config,
-///     false,
 ///     false,
 ///     10,
 ///     false,
@@ -142,9 +161,8 @@ fn lin_dist_range(buckets: usize, slices: usize) -> Vec<Range<usize>> {
 #[inline(never)]
 //pub fn filter_kmers_parallel<K: Kmer + Sync + Send, V: Vmer + Sync, D1: Clone + Debug + Sync, DS: Clone + Sync + Send, S: KmerSummarizer<D1, DS, (usize, usize)> +  Send>(
 pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug + Send + SummaryData<u8>>(
-    seqs: &Reads<u8>,
+    seqs: &ReadsPaired<u8>,
     summariy_config: &SummaryConfig,
-    stranded: bool,
     report_all_kmers: bool,
     memory_size: usize,
     time: bool,
@@ -153,11 +171,15 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
     // take timestamp before all processes
     let before_all = Instant::now();
 
-    let rc_norm = !stranded;
+    // progress bars
+    let multi_pb = MultiProgress::new();
+    let style = ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-");
 
     // Estimate 6 consumed by Kmer vectors, and set iteration count appropriately
     let input_kmers: usize = seqs
+        .iterable()
         .iter()
+        .flat_map(|reads| reads.iter())
         .map(|(ref read, _, _)| read.len().saturating_sub(K::k() - 1))
         .sum();
 
@@ -169,22 +191,77 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
     let slices = slices_seq;
     //let sz = buckets / slices + 1;
 
+
+    // split all reads into ranges to be processed in parallel for counting capacities and picking kmers
+    let n_threads = current_num_threads();
+    let n_reads = seqs.n_reads();
+    let sz = n_reads / n_threads + 1;
+
+    debug!("n_reads: {}", n_reads);
+    debug!("sz: {}", sz);
+
+    let mut parallel_ranges = Vec::with_capacity(n_threads);
+    let mut start = 0;
+    while start < n_reads {
+        parallel_ranges.push(start..start + sz);
+        start += sz;
+    }
+
+    let last_start = parallel_ranges.pop().expect("no kmers in parallel ranges").start;
+    parallel_ranges.push(last_start..n_reads);
+    debug!("parallel ranges: {:?}", parallel_ranges);
+
     debug!("kmers: {}, mem per kmer: {}, kmer_mem: {} Bytes, slices: {}", input_kmers, mem::size_of::<(K, Exts, u8)>(), kmer_mem, slices);
-    
-    // split ranges into slices according to constant probrbiliy dist. if stranded, else according to linear probability distribition
-    let bucket_ranges: Vec<std::ops::Range<usize>> = if stranded {
-        let mut bucket_ranges = Vec::with_capacity(slices);
-        let mut start = 0;
-        let sz = BUCKETS / slices + 1;
-        while start < BUCKETS {
-            bucket_ranges.push(start..start + sz);
-            start += sz;
+
+    let capacities = Arc::new(Mutex::new(vec![[0; BUCKETS]; n_threads]));
+
+    let pb_size_buckets = multi_pb.add(ProgressBar::new(seqs.n_reads() as u64));
+    pb_size_buckets.set_style(style.clone());
+    pb_size_buckets.set_message(format!("{:<32}", "finding bucket sizes"));
+
+    parallel_ranges.clone().into_par_iter().enumerate().for_each(|(i, range)| {
+
+        // first go trough all kmers to find the length of all buckets (to reserve capacity)
+        let mut thread_capacities = [0usize; BUCKETS];
+        for ((ref seq, _, _), stranded) in seqs
+            .iterable()
+            .iter()
+            .flat_map(|reads| reads
+                .partial_iter(range.clone())
+                .map(|read| (read, reads.stranded()))) 
+        { 
+            // iterate through all kmers in seq
+            for kmer in seq.iter_kmers::<K>() {
+                // calculate which bucket this kmer belongs to
+                thread_capacities[bucket_flip(kmer, stranded)] += 1;
+            }
+            pb_size_buckets.inc(1);
         }
-        bucket_ranges
-    } else {
-        lin_dist_range(BUCKETS, slices)
-    };
-        
+
+        let mut cap = capacities.lock().expect("error locking capacity mutex");
+        cap[i] = thread_capacities;
+    });
+
+    let capacities = capacities.lock().expect("error in final lock capacites");
+    
+    // split ranges into slices according no of kmers inside
+    let mut start_bucket = 0;
+    let mut size = 0;
+
+    let max_size = max_mem / slices;
+
+    let mut bucket_ranges = Vec::with_capacity(slices);
+
+    for i in 0..BUCKETS {
+        let capacity = capacities.iter().map(|c_bucket| c_bucket[i]).sum::<usize>(); 
+        size += capacity;
+        if size > max_size {
+            bucket_ranges.push(start_bucket..i);
+            start_bucket = i;
+            size = capacity;
+        }
+    }   
+    bucket_ranges.push(start_bucket..BUCKETS);
 
     debug!("bucket_ranges: {:?}, len br: {}", bucket_ranges, bucket_ranges.len());
     assert!(bucket_ranges[bucket_ranges.len() - 1].end >= BUCKETS);
@@ -209,10 +286,6 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 
     if time { println!("time all prepariations before sliced in filter_kmers (s): {}", before_all.elapsed().as_secs_f32()) }
 
-    // progress bars
-    let multi_pb = MultiProgress::new();
-    let style = ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-");
-
     let pb_bucket_ranges = multi_pb.add(ProgressBar::new(bucket_ranges.len() as u64));
     pb_bucket_ranges.set_style(style.clone());
     pb_bucket_ranges.set_message(format!("{:<32}", "filtering kmers"));
@@ -228,35 +301,10 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
         // when using the first four bases, this needs 256 buckets
         // the buckets are split in to the bucket_ranges to save memory
 
-        // split all reads into ranges to be processed in parallel for counting capacities and picking kmers
-
-        let n_threads = current_num_threads();
-        let n_reads = seqs.n_reads();
-        let sz = n_reads / n_threads + 1;
-
-        debug!("n_reads: {}", n_reads);
-        debug!("sz: {}", sz);
-
-        let mut parallel_ranges = Vec::with_capacity(slices);
-        let mut start = 0;
-        while start < n_reads {
-            parallel_ranges.push(start..start + sz);
-            start += sz;
-        }
-
-        let last_start = parallel_ranges.pop().expect("no kmers in parallel ranges").start;
-        parallel_ranges.push(last_start..n_reads);
-        debug!("parallel ranges: {:?}", parallel_ranges);
-
 
         let kmer_buckets = Arc::new(Mutex::new(vec![Vec::new(); n_threads]));
 
         let before_picking_parallel = Instant::now();
-
-        let pb_size_buckets = multi_pb.add(ProgressBar::new(seqs.n_reads() as u64));
-        pb_size_buckets.set_style(style.clone());
-        pb_size_buckets.set_message(format!("{:<32}", "finding bucket sizes"));
-        
 
         let pb_fill_buckets = multi_pb.add(ProgressBar::new(seqs.n_reads() as u64));
         pb_fill_buckets.set_style(style.clone());
@@ -267,58 +315,27 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
         pb_sum_buckets.set_message(format!("{:<32}", "summarizing k-mers in buckets"));
 
         parallel_ranges.clone().into_par_iter().enumerate().for_each(|(i, range)| {
-
-            // first go trough all kmers to find the length of all buckets (to reserve capacity)
-            let mut capacities = [0usize; BUCKETS];
-            for (ref seq, _, _) in seqs.partial_iter(range.clone()) { 
-                // iterate through all kmers in seq
-                for kmer in seq.iter_kmers::<K>() {
-                    // if not stranded choose lexiographically lesser of kmer and rc of kmer
-                    let min_kmer = if rc_norm {
-                        let (min_kmer, _) = kmer.min_rc_flip();
-                        min_kmer
-                    } else {
-                        kmer
-                    };
-
-                    // calculate which bucket this kmer belongs to
-                    let bucket = if K::k() > 3 { bucket(min_kmer) } else { min_kmer.to_u64() as usize };
-                    //let bucket = bucket(min_kmer);
-                    // check if bucket is in current range and if so, add one to needed capacity
-                    let in_range = bucket >= bucket_range.start && bucket < bucket_range.end;
-                    if in_range { 
-                        capacities[bucket] += 1;
-                    }
-                }
-                pb_size_buckets.inc(1);
-            }
-
             let mut kmer_buckets1d = Vec::with_capacity(BUCKETS); 
             
             // reserve capacities needed for current range in each bucket
-            for capacity in capacities.into_iter() {
+            for capacity in capacities[i].into_iter() {
                 kmer_buckets1d.push(Vec::with_capacity(capacity));
             }
 
             // fill buckets with kmers
-            for (ref seq, seq_exts, ref d) in seqs.partial_iter(range) {
+            for ((ref seq, seq_exts, ref d), stranded) in seqs
+                .iterable()
+                .iter()
+                .flat_map(|reads| reads.partial_iter(range.clone())
+                    .map(|read| (read, reads.stranded()))) 
+            {
                 for (kmer, exts) in seq.iter_kmer_exts::<K>(seq_exts) {
-                    let (min_kmer, flip_exts) = if rc_norm {
-                        let (min_kmer, flip) = kmer.min_rc_flip();
-                        let flip_exts = if flip { exts.rc() } else { exts };
-                        (min_kmer, flip_exts)
-                    } else {
-                        (kmer, exts)
-                    };
-
-                    // calculate which bucket this kmer belongs to
-                    let bucket = if K::k() > 3 { bucket(min_kmer) } else { min_kmer.to_u64() as usize };
-                    //let bucket = bucket(min_kmer);
+                    // if needed, flip kmer and exts
                     // check if bucket is in current range and if so, push kmer to bucket
-                    let in_range = bucket >= bucket_range.start && bucket < bucket_range.end;
-                    if in_range {
+                    if let Some((min_kmer, flip_exts, bucket)) = bucket_ext_flip(kmer, exts, stranded, bucket_range.clone()) {
                         kmer_buckets1d[bucket].push((min_kmer, flip_exts, *d));
                     }
+
                 }
 
                 pb_fill_buckets.inc(1);
@@ -491,12 +508,12 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 /// 
 /// ```
 /// use debruijn::summarizer::{SampleInfo, SummaryConfig, TagsCountsData, StatTest, GroupFrac};
-/// use debruijn::reads::Reads;
+/// use debruijn::reads::{Reads, ReadsPaired, Stranded};
 /// use debruijn::filter::filter_kmers;
 /// use debruijn::kmer::Kmer16;
 /// use debruijn::Exts;
 /// 
-/// let mut seqs = Reads::new();
+/// let mut seqs = Reads::new(Stranded::Unstranded);
 /// seqs.add_from_bytes("ACCGATCATATATTTTCGGGGCTAGGCGAAGCGATCTTATCGAGC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGATCGAGCATGCTCAGCTGACGTGACTGACGTAGCTATCTTTTCGTAGCTAC".as_bytes(), Exts::empty(), 1u8);
 /// seqs.add_from_bytes("GCGAGTTTGCGACTCGAGGCTATCTAGCTAGCTASGCTCTCGACTAGCTGACTTACGACGACTACG".as_bytes(), Exts::empty(), 2u8);
@@ -521,9 +538,8 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 /// );
 ///    
 /// let (hashed_kmers, _) = filter_kmers::<TagsCountsData, Kmer16, _>(
-///     &seqs,
+///     &ReadsPaired::Unpaired { reads: seqs },
 ///     &summary_config,
-///     false,
 ///     false,
 ///     10,
 ///    false,
@@ -531,9 +547,8 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 /// ```
 #[inline(never)]
 pub fn filter_kmers<SD, K: Kmer, D1: Copy + Clone + Debug>(
-    seqs: &Reads<D1>,
+    seqs: &ReadsPaired<D1>,
     summary_config: &SummaryConfig,
-    stranded: bool,
     report_all_kmers: bool,
     memory_size: usize,
     time: bool,
@@ -542,11 +557,16 @@ where
     SD: Debug + SummaryData<D1>,
 {
     let before_all = Instant::now();
-    let rc_norm = !stranded;
+
+    // progress bars
+    let multi_pb = MultiProgress::new();
+    let style = ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-");
 
     // Estimate memory consumed by Kmer vectors, and set iteration count appropriately
     let input_kmers: usize = seqs
+        .iterable()
         .iter()
+        .flat_map(|reads| reads.iter())
         .map(|(ref read, _, _)| read.len().saturating_sub(K::k() - 1))
         .sum();
 
@@ -560,20 +580,48 @@ where
 
     let max_mem: usize = memory_size * 10_usize.pow(9);
     let slices: usize = kmer_mem / max_mem + 1;
-  
-    // split ranges into slices according to constant probrbiliy dist. if stranded, else according to linear probability distribition
-    let bucket_ranges: Vec<std::ops::Range<usize>> = if stranded {
-        let mut bucket_ranges = Vec::with_capacity(slices);
-        let mut start = 0;
-        let sz = BUCKETS / slices + 1;
-        while start < BUCKETS {
-            bucket_ranges.push(start..start + sz);
-            start += sz;
+
+    let pb = multi_pb.add(ProgressBar::new(seqs.n_reads() as u64));
+    pb.set_style(style.clone());
+    pb.set_message(format!("{:<32}", "finding bucket lengths"));
+
+
+    // first go trough all kmers to find the length of all buckets (to reserve capacity)
+    let mut capacities = [0; BUCKETS];
+
+    for ((ref seq, _, _), stranded) in seqs
+        .iterable()
+        .iter()
+        .flat_map(|reads| reads
+            .iter()
+            .map(|read| (read, reads.stranded())))
+        .progress_with(pb) 
+    {
+        // iterate through all kmers in seq
+        for kmer in seq.iter_kmers::<K>() {
+            // calculate which bucket this kmer belongs to
+            capacities[bucket_flip(kmer, stranded)] += 1 
         }
-        bucket_ranges
-    } else {
-        lin_dist_range(BUCKETS, slices)
-    };
+    }
+
+    debug!("kmer capacities: {:?}, times {}", capacities, mem::size_of::<(K, Exts, D1)>());
+
+    let mut start_bucket = 0;
+    let mut size = 0;
+
+    let max_size = max_mem / slices;
+
+    let mut bucket_ranges = Vec::with_capacity(slices);
+
+    for (i, capacity) in capacities.iter().enumerate() {
+        size += capacity;
+        if size > max_size {
+            bucket_ranges.push(start_bucket..i);
+            start_bucket = i;
+            size = *capacity;
+        }
+    }
+    bucket_ranges.push(start_bucket..BUCKETS);
 
     debug!("bucket ranges: {:?}", bucket_ranges);
 
@@ -606,13 +654,10 @@ where
 
     if time { println!("time all prepariations before sliced in filter_kmers (s): {}", before_all.elapsed().as_secs_f32()) }
 
-    // progress bars
-    let multi_pb = MultiProgress::new();
-    let style = ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-");
-
     let pb_bucket_ranges = multi_pb.add(ProgressBar::new(bucket_ranges.len() as u64));
     pb_bucket_ranges.set_style(style.clone());
     pb_bucket_ranges.set_message(format!("{:<32}", "filtering k-mers"));
+
 
     // iterate over the bucket ranges
     for (i, bucket_range) in bucket_ranges.into_iter().enumerate() {
@@ -624,34 +669,6 @@ where
         // all kmers starting with "AAAA" go in kmer_buckets[0], all starting with AAAC go in kmer_buckets[1] and so on
         // when using the first four bases, this needs 256 buckets
         // the buckets are split in to the bucket_ranges to save memory
-
-        let pb = multi_pb.add(ProgressBar::new(seqs.n_reads() as u64));
-        pb.set_style(style.clone());
-        pb.set_message(format!("{:<32}", "finding bucket lengths"));
-
-        // first go trough all kmers to find the length of all buckets (to reserve capacity)
-        let mut capacities = [0; BUCKETS];
-
-        for (ref seq, _, _) in seqs.iter().progress_with(pb) {
-            // iterate through all kmers in seq
-            for kmer in seq.iter_kmers::<K>() {
-                // if not stranded choose lexiographically lesser of kmer and rc of kmer
-                let min_kmer = if rc_norm {
-                    let (min_kmer, _) = kmer.min_rc_flip();
-                    min_kmer
-                } else {
-                    kmer
-                };
-
-                // calculate which bucket this kmer belongs to
-                let bucket = if K::k() > 3 { bucket(min_kmer) } else { min_kmer.to_u64() as usize };
-                //let bucket = bucket(min_kmer);                // check if bucket is in current range and if so, add one to needed capacity
-                let in_range = bucket >= bucket_range.start && bucket < bucket_range.end;
-                if in_range { capacities[bucket] += 1 }
-            }
-        }
-
-        debug!("kmer capacities: {:?}, times {}", capacities, mem::size_of::<(K, Exts, D1)>());
         
         let mut kmer_buckets = Vec::new();
         // reserve needed capacity in each bucket
@@ -664,24 +681,19 @@ where
         pb.set_style(style.clone());
         pb.set_message(format!("{:<32}", "filling buckets with kmers"));
 
-        for (ref seq, seq_exts, ref d) in seqs.iter().progress_with(pb) {
+        for ((ref seq, seq_exts, ref d), stranded) in seqs
+            .iterable()
+            .iter()
+            .flat_map(|reads| reads
+                .iter()
+                .map(|read| (read, reads.stranded())))
+            .progress_with(pb) 
+        {
             // iterate trough all kmers in seq
             for (kmer, exts) in seq.iter_kmer_exts::<K>(seq_exts) {
-                // // if not stranded choose lexiographically lesser of kmer and rc of kmer, flip exts if needed
-                let (min_kmer, flip_exts) = if rc_norm {
-                    let (min_kmer, flip) = kmer.min_rc_flip();
-                    let flip_exts = if flip { exts.rc() } else { exts };
-                    (min_kmer, flip_exts)
-                } else {
-                    (kmer, exts)
-                };
-
-                // calculate which bucket this kmer belongs to
-                let bucket = if K::k() > 3 { bucket(min_kmer) } else { min_kmer.to_u64() as usize };
-                //let bucket = bucket(min_kmer);
+                // if needed, flip kmer and exts
                 // check if bucket is in current range and if so, push kmer to bucket
-                let in_range = bucket >= bucket_range.start && bucket < bucket_range.end;
-                if in_range {
+                if let Some((min_kmer, flip_exts, bucket)) = bucket_ext_flip(kmer, exts, stranded, bucket_range.clone()) {
                     kmer_buckets[bucket].push((min_kmer, flip_exts, *d));
                 }
             }
@@ -883,7 +895,7 @@ mod tests {
             (DnaString::from_dna_string("AAAAAAAAAAAAA"), Exts::empty(), 7u8),
         ];
 
-        let mut reads = Reads::new();
+        let mut reads = Reads::new(crate::reads::Stranded::Unstranded);
 
         for (read, exts, data) in fastq {
             reads.add_read(read, exts, data);
@@ -895,9 +907,8 @@ mod tests {
 
 
         let (hm, _): (BoomHashMap2<Kmer6, Exts, TagsSumData>, Vec<_>) = filter_kmers(
-            &reads, 
+            &ReadsPaired::Unpaired { reads }, 
             &config,
-            false, 
             false, 
             1,
             false,
@@ -922,7 +933,7 @@ mod tests {
 
         } */
 
-        let mut reads = Reads::new();
+        let mut reads = Reads::new(crate::reads::Stranded::Unstranded);
 
         for _i in 0..10000 {
             let dna = random_dna(150);
@@ -934,9 +945,8 @@ mod tests {
 
 
         let (hm, _): (BoomHashMap2<Kmer6, Exts, TagsSumData>, Vec<_>) = filter_kmers_parallel(
-            &reads, 
+            &ReadsPaired::Unpaired { reads }, 
             &config,
-            false, 
             false, 
             1,
             false,         
@@ -945,4 +955,5 @@ mod tests {
         println!("{:?}", hm);
 
     }
+
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -379,6 +379,8 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
     }
 
     /// Remove non-existent extensions that may be created due to filtered kmers
+    /// 
+    /// if `valid_nodes` if `None`, all nodes are valid
     pub fn fix_exts(&mut self, valid_nodes: Option<&BitSet>) {
         for i in 0..self.len() {
             let valid_exts = self.get_valid_exts(i, valid_nodes);
@@ -1405,6 +1407,15 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
 impl<K: Kmer, SD: SummaryData<u8> + Debug> DebruijnGraph<K, SD> {
     pub fn create_colors(&self, config: &SummaryConfig) -> Colors<SD> {
         Colors::new(self, config)
+    }
+    
+    /// edge mults will contain hanging edges if the nodes were filtered
+    pub fn fix_edge_mults(&mut self) {
+        if self.get_node(0).data().edge_mults().is_some() {
+            for i in 0..self.len() {
+                self.base.data[i].fix_edge_mults(self.base.exts[i]);
+            }
+        }
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -839,6 +839,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT file"));
 
+        writeln!(&mut f, "# {:?}", nodes).unwrap();
         writeln!(&mut f, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
         for i in nodes.into_iter().progress_with(pb) {
             self.node_to_dot(&self.get_node(i), node_label, edge_label, &mut f);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1674,10 +1674,11 @@ impl<K: Kmer, SD: SummaryData<u8> + Debug> Node<'_, K, SD>  {
         const MIN_TEXT_WIDTH: usize = 40;
         let wrap = if self.len() > MIN_TEXT_WIDTH { self.len() } else { MIN_TEXT_WIDTH };
 
-        let label = textwrap::fill(&format!("id: {}, len: {}, seq: {}, {}", 
+        let label = textwrap::fill(&format!("id: {}, len: {}, seq: {}, exts: {:?}, {}", 
             self.node_id,
             self.len(),
             self.sequence(),
+            self.exts(),
             data_info
         ), wrap);
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -42,6 +42,7 @@ use crate::dna_string::{DnaString, DnaStringSlice, PackedDnaStringSet};
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
 use crate::BUF;
+use crate::PROGRESS_STYLE;
 use crate::{Dir, Exts, Kmer, Mer, Vmer};
 
 /// A compressed DeBruijn graph carrying auxiliary data on each node of type `D`.
@@ -738,7 +739,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let mut f = BufWriter::with_capacity(BUF, File::create(path).expect("error creating dot file"));
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT file"));
 
         writeln!(&mut f, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
@@ -795,7 +796,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         } 
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT files"));
     
         parallel_ranges.into_par_iter().enumerate().for_each(|(i, range)| {
@@ -815,7 +816,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(&mut out_file, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
 
         let pb = ProgressBar::new(files.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "combining files"));
 
         for file in files.iter().progress_with(pb) {
@@ -857,7 +858,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let mut f = BufWriter::with_capacity(BUF, File::create(path).expect("error creating dot file"));
 
         let pb = ProgressBar::new(nodes.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to DOT file"));
 
         writeln!(&mut f, "# {:?}", nodes).unwrap();
@@ -947,7 +948,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let dummy_opt: Option<&DummyFn<K, D>> = None;
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
 
         for i in (0..self.len()).progress_with(pb) {
@@ -970,7 +971,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(wtr, "H\tVN:Z:debruijn-rs")?;
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
 
         for i in (0..self.len()).progress_with(pb) {
@@ -1020,7 +1021,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         } 
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
         
         
@@ -1043,7 +1044,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(out_file, "H\tVN:Z:debruijn-rs")?;
 
         let pb = ProgressBar::new(files.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "combining files"));
 
         for file in files.iter() {
@@ -1071,7 +1072,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         writeln!(wtr, "H\tVN:Z:debruijn-rs")?;
 
         let pb = ProgressBar::new(self.len() as u64);
-        pb.set_style(ProgressStyle::with_template("{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})").unwrap().progress_chars("#/-"));
+        pb.set_style(ProgressStyle::with_template(PROGRESS_STYLE).unwrap().progress_chars("#/-"));
         pb.set_message(format!("{:<32}", "writing graph to GFA file"));
 
         for i in nodes.into_iter().progress_with(pb) {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -252,6 +252,26 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
 
         for i in 0..4 {
             if exts.has_ext(dir, i) {
+                let link = self.find_link(kmer.extend(i, dir), dir).expect("missing link");
+                edges.push((i, link.0, link.1, link.2));
+            }
+        }
+
+        edges
+    }
+
+    /// Find the edges leaving node `node_id` in direction `Dir`. Should generally be
+    /// accessed via a Node wrapper object
+    /// 
+    /// allows missing links
+    fn _find_edges_sharded(&self, node_id: usize, dir: Dir) -> SmallVec4<(u8, usize, Dir, bool)> {
+        let exts = self.base.exts[node_id];
+        let sequence = self.base.sequences.get(node_id);
+        let kmer: K = sequence.term_kmer(dir);
+        let mut edges = SmallVec4::new();
+
+        for i in 0..4 {
+            if exts.has_ext(dir, i) {
                 let link = self.find_link(kmer.extend(i, dir), dir); //.expect("missing link");
                 if let Some(l) = link {
                     edges.push((i, l.0, l.1, l.2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1109,7 +1109,12 @@ impl EdgeMult {
         self.edge_mults[dir.index(base) as usize] += count
     }
 
-    /// add an `Exts` to the `EdgeMult`
+    /// remove an edge from the `EdgeMult`
+    pub fn remove(&mut self, base: u8, dir: Dir) {
+        self.edge_mults[dir.index(base) as usize] = 0;
+    }
+
+    /// add an [`Exts`] to the `EdgeMult`
     pub fn add_exts(&mut self, exts: Exts) {
         let mut exts = exts.val;
         for index in (0..(2 * ALPHABET_SIZE)).rev() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod colors;
 const BUF: usize = 64*1024;
 const BUCKETS: usize = 256;
 const ALPHABET_SIZE: usize = 4;
+const PROGRESS_STYLE: &str = "{msg} [{elapsed_precise}] {bar:60.cyan/blue} ({pos}/{len})";
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod bitops_avx2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1159,6 +1159,19 @@ impl EdgeMult {
 
         Exts::new(exts_val)
     }
+
+    /// clean the edge mults by removing edge counts that led to filtered kmers
+    /// based on a correct [`Exts`]
+    pub fn clean_edges(&mut self, exts: Exts) {
+        let mut exts = exts.val;
+        for index in (0..(2 * ALPHABET_SIZE)).rev() {
+            if exts % 2 == 0 {
+                self.edge_mults[index] = 0;
+            }
+            exts >>= 1;
+        }
+        
+    }
 }
 
 impl Default for EdgeMult {
@@ -1218,6 +1231,10 @@ mod tests {
         let exts = Exts::new(0b01010101);
         edge_mult.add_exts(exts);
         assert_eq!(edge_mult.edge_mults, [2, 2, 2, 4, 2, 78991, 2, 2]);
+
+        let clean_exts = Exts::new(0b10010101);
+        edge_mult.clean_edges(clean_exts);
+        assert_eq!(edge_mult.edge_mults, [2, 0, 0, 4, 0, 78991, 0, 2]);
 
         let mut em = EdgeMult::new();
         let exts = Exts::new(0b00011101);

--- a/src/test.rs
+++ b/src/test.rs
@@ -153,7 +153,7 @@ mod tests {
     use crate::kmer::{IntKmer, VarIntKmer, K31};
     use crate::msp;
     use std::ops::Sub;
-    use crate::summarizer::{GroupFrac, SampleInfo, SummaryConfig, TagsCountsSumData, TagsSumData};
+    use crate::summarizer::{GroupFrac, SampleInfo, SummaryConfig, TagsCountsEMData, TagsCountsSumData, TagsSumData};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -561,7 +561,7 @@ mod tests {
         }
 
         let sample_info = SampleInfo::new(0, 0, 0, 0,Vec::new());
-        let config = SummaryConfig::new(1, None, GroupFrac::None, 0.33, sample_info.clone(), None, crate::summarizer::StatTest::StudentsTTest);
+        let config = SummaryConfig::new(2, None, GroupFrac::None, 0.33, sample_info.clone(), None, crate::summarizer::StatTest::StudentsTTest);
 
         // Assemble w/o tips
         let (valid_kmers_clean, _): (BoomHashMap2<K, Exts, u32>, _) = filter::filter_kmers(
@@ -604,7 +604,7 @@ mod tests {
             4,
             true,
         );
-        let (_valid_kmers_errs4, _): (BoomHashMap2<K, Exts, TagsCountsSumData>, _) = filter::filter_kmers_parallel(
+        let (_valid_kmers_errs4, _): (BoomHashMap2<K, Exts, TagsCountsEMData>, _) = filter::filter_kmers_parallel(
             &all_seqs_p,
             &config,
             stranded,
@@ -622,7 +622,9 @@ mod tests {
         let graph = compress_kmers_with_hash(stranded, &spec, &valid_kmers_errs, true, false, true);
         println!("graph: {:?}", graph);
 
-        let graph = graph.finish();
+        let mut graph = graph.finish();
+        graph.fix_exts(None);
+        graph.fix_edge_mults();
         graph.print();
         /* graph.to_dot("test_out", &|d| format!("{:?}", d));
         graph.to_dot_parallel("test_out_par", &|d  format!("{:?}", d)); */

--- a/tests/test_colors.rs
+++ b/tests/test_colors.rs
@@ -27,28 +27,28 @@ fn test_colors() {
     
     let node_id = 0;
     let node = graph.get_node(node_id);
-    assert_eq!("[style=filled, color=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 0, len: 16, seq: CCAGCTGTCCCAGATA,\nsamples              - counts\nC_H600               - 1\nsum: 1, p-value: 0.37390098, log2(fold\nchange): inf, edge multiplicities:\nA: 1 | 0\nC: 0 | 1\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, false));
-    assert_eq!("[color=blue, penwidth=1, label=\"1\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Left, true));
+    assert_eq!("[style=filled, color=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 0, len: 16, exts: A|C, seq:\nCCAGCTGTCCCAGATA, samples              -\ncounts\nC_H600               - 1\nsum: 1, p-value: 0.37390098, log2(fold\nchange): inf, edge multiplicities:\nA: 1 | 0\nC: 0 | 1\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, false));
+    assert_eq!("[color=blue, penwidth=1, label=\"A: 1\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Left, true));
 
     let node_id = 3;
     let node = graph.get_node(node_id);
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 3, len: 16, seq: CCGATACTTCTTCACG,\nsamples              - counts\nC_H200               - 1\nC_H300               - 1\nC_H500               - 1\nC_H600               - 1\nsum: 4, p-value: 0.05366346, log2(fold\nchange): inf, edge multiplicities:\nA: 0 | 0\nC: 0 | 4\nG: 0 | 0\nT: 4 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
-    assert_eq!("[color=red, penwidth=8.469343, label=\"4\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 3, len: 16, exts: T|C, seq:\nCCGATACTTCTTCACG, samples              -\ncounts\nC_H200               - 1\nC_H300               - 1\nC_H500               - 1\nC_H600               - 1\nsum: 4, p-value: 0.05366346, log2(fold\nchange): inf, edge multiplicities:\nA: 0 | 0\nC: 0 | 4\nG: 0 | 0\nT: 4 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
+    assert_eq!("[color=red, penwidth=8.469343, label=\"C: 4\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
 
     let node_id = 27;
     let node = graph.get_node(node_id);
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 0.5 1\", fontcolor=black, label=\"id: 27, len: 16, seq: CAGGTCCGTGGCCAGG,\nsamples              - counts\nP_T400               - 1\nsum: 1, p-value: 0.3910022, log2(fold\nchange): -inf, edge multiplicities:\nA: 0 | 0\nC: 1 | 0\nG: 0 | 1\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
-    assert_eq!("[color=red, penwidth=-inf, label=\"0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 0.5 1\", fontcolor=black, label=\"id: 27, len: 16, exts: C|G, seq:\nCAGGTCCGTGGCCAGG, samples              -\ncounts\nP_T400               - 1\nsum: 1, p-value: 0.3910022, log2(fold\nchange): -inf, edge multiplicities:\nA: 0 | 0\nC: 1 | 0\nG: 0 | 1\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
+    assert_eq!("[color=red, penwidth=-inf, label=\"C: 0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
 
     let node_id = 40;
     let node = graph.get_node(node_id);
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.15937972 0.5 1\", fontcolor=black, label=\"id: 40, len: 16, seq: GCTTTGCATCAGAAGA,\nsamples              - counts\nC_H100               - 1\nC_H400               - 2\nP_T200               - 1\nP_T300               - 1\nP_T400               - 1\nsum: 6, p-value: 0.86424315,\nlog2(fold change): -0.19431013, edge\nmultiplicities:\nA: 6 | 3\nC: 0 | 0\nG: 0 | 3\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
-    assert_eq!("[color=red, penwidth=-inf, label=\"0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.15937972 0.5 1\", fontcolor=black, label=\"id: 40, len: 16, exts: A|AG, seq:\nGCTTTGCATCAGAAGA, samples              -\ncounts\nC_H100               - 1\nC_H400               - 2\nP_T200               - 1\nP_T300               - 1\nP_T400               - 1\nsum: 6, p-value: 0.86424315,\nlog2(fold change): -0.19431013, edge\nmultiplicities:\nA: 6 | 3\nC: 0 | 0\nG: 0 | 3\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
+    assert_eq!("[color=red, penwidth=-inf, label=\"C: 0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
     
     let node_id = 2458;
     let node = graph.get_node(node_id);
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 1 1\", fontcolor=black, label=\"id: 2458, len: 16, seq:\nTCTCGTACTAAGTTCA, samples              -\ncounts\nC_H600               - 1\nP_T100               - 1\nP_T200               - 1\nP_T300               - 1\nP_T400               - 2\nsum: 6, p-value: 0.030437965,\nlog2(fold change): -4.4442472, edge\nmultiplicities:\nA: 0 | 6\nC: 6 | 0\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
-    assert_eq!("[color=red, penwidth=-inf, label=\"0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 1 1\", fontcolor=black, label=\"id: 2458, len: 16, exts: C|A, seq:\nTCTCGTACTAAGTTCA, samples              -\ncounts\nC_H600               - 1\nP_T100               - 1\nP_T200               - 1\nP_T300               - 1\nP_T400               - 2\nsum: 6, p-value: 0.030437965,\nlog2(fold change): -4.4442472, edge\nmultiplicities:\nA: 0 | 6\nC: 6 | 0\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config, &hashed_labels, true));
+    assert_eq!("[color=red, penwidth=-inf, label=\"C: 0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
 
     // write node to dot
 

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -30,11 +30,11 @@ where
 
     let em = data.edge_mults().cloned();
 
-    if data.edge_mults().is_some() {
-        data.fix_edge_mults(Exts::new(0));
-        assert_eq!(data.edge_mults().unwrap().edge_mults(), [0; 8]);
+    data.fix_edge_mults(Exts::new(0));
+    if let Some(e) = data.edge_mults() {
+        assert_eq!(e.edge_mults(), [0; 8]);
     }
-
+    
     (
         count,
         tags_sum,

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -8,7 +8,7 @@ fn test_summarize<SD: SummaryData<u8>, F, K: Kmer>(items: F, config: &SummaryCon
 where 
     F: Iterator<Item = (K, Exts, u8)>,
 {
-    let (valid, _, data) = SD::summarize(items, config);
+    let (valid, _, mut data) = SD::summarize(items, config);
 
     let count = data.count();
     let score = data.score();
@@ -29,6 +29,11 @@ where
     assert_eq!(data.valid(config), valid);
 
     let em = data.edge_mults().cloned();
+
+    if data.edge_mults().is_some() {
+        data.fix_edge_mults(Exts::new(0));
+        assert_eq!(data.edge_mults().unwrap().edge_mults(), [0; 8]);
+    }
 
     (
         count,
@@ -109,14 +114,14 @@ fn test_summary_data() {
 
     let data = test_summarize::<TagsCountsEMData, _, _>(input.into_iter(), &summary_config, &tag_translator);
     assert_eq!(data, (count, tags_sum, size_tags + 16 + 6*4 + 4*8, p_value, fold_change, sample_count, edge_mults.clone(), true, 
-        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 6 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
-        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 6, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
+        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 0 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 0, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
     )); 
 
     let data = test_summarize::<TagsCountsPEMData, _, _>(input.into_iter(), &summary_config, &tag_translator);
     assert_eq!(data, (count, tags_sum, size_tags * 2 + 16 + 6*4 + 4*8, p_value, fold_change, sample_count, edge_mults.clone(), true,  
-        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 6 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
-        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 6, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
+        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 0 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 0, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
     )); 
 
     let data = test_summarize::<GroupCountData, _, _>(input.into_iter(), &summary_config, &tag_translator);
@@ -128,21 +133,21 @@ fn test_summary_data() {
     let summary_config = SummaryConfig::new(1, None, GroupFrac::One, 0.33, sample_info.clone(), None, summarizer::StatTest::WelchsTTest);
     let data = test_summarize::<TagsCountsPEMData, _, _>(input.into_iter(), &summary_config, &tag_translator);
     assert_eq!(data, (count, tags_sum, size_tags * 2 + 16 + 6*4 + 4*8, p_value, fold_change, sample_count, edge_mults.clone(), true,  
-        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 6 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
-        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 6, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
+        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 0 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 0, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
     )); 
 
     let summary_config = SummaryConfig::new(1, None, GroupFrac::Both, 0.33, sample_info.clone(), None, summarizer::StatTest::WelchsTTest);
     let data = test_summarize::<TagsCountsPEMData, _, _>(input.into_iter(), &summary_config, &tag_translator);
     assert_eq!(data, (count, tags_sum, size_tags * 2 + 16 + 6*4 + 4*8, p_value, fold_change, sample_count, edge_mults.clone(), false,  
-        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 6 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
-        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 6, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
+        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 0 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 0, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
     )); 
 
     let summary_config = SummaryConfig::new(1, None, GroupFrac::One, 0.33, sample_info.clone(), Some(0.05), summarizer::StatTest::WelchsTTest);
     let data = test_summarize::<TagsCountsPEMData, _, _>(input.into_iter(), &summary_config, &tag_translator);
     assert_eq!(data, (count, tags_sum, size_tags * 2 + 16 + 6*4 + 4*8, p_value, fold_change, sample_count, edge_mults.clone(), false,  
-        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 6 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
-        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 6, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
+        "samples              - counts\n0                    - 1\n1                    - 1\n2                    - 1\n3                    - 1\n7                    - 1\n8                    - 1\nsum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: \nA: 0 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        "samples: ['0', '1', '2', '3', '7', '8'], counts: [1, 1, 1, 1, 1, 1], sum: 6, p-value: 0.39023498, log2(fold change): 5.4498405, edge multiplicities: A: 0, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string()
     )); 
 }


### PR DESCRIPTION
Add option to keep reads as paired & stranded 
- add new `ReadsPaired` to store paired reads in
- add `Stranded` to `Reads` to store strandedness
- adapt `filter_kmers` and `filter_kmers_parallel` to respect strandedness of reads

Disconnected edges in graph
- use checked version of `Node::find_edges`
- add `EdgeMult::clean_edges` to correct edge multiplicities for filtered nodes