### PR TITLE
Fix/unreachable kmers

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -436,7 +436,7 @@ impl<K: Kmer +  Send + Sync, D: Clone + Debug + Send + Sync, S: CompressionSpec<
 
             let mut do_flip = false;
             
-            // decide if direction needs to be changed (how?????????) turn kmer into rc
+            // decide if direction needs to be changed turn kmer into rc
             if !self.stranded {
                 let flip_rc = next_kmer.min_rc_flip();
                 do_flip = flip_rc.1;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -21,7 +21,7 @@ use rayon::current_num_threads;
 use rayon::prelude::*;
 
 use crate::reads::ReadsPaired;
-use crate::reads::Stranded;
+use crate::reads::Strandedness;
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
 use crate::Dir;
@@ -39,17 +39,17 @@ pub fn bucket<K: Kmer>(kmer: K) -> usize {
         | (kmer.get(3) as usize)
 }
 
-fn bucket_flip<K: Kmer>(kmer: K, stranded: Stranded) -> usize {
+fn bucket_flip<K: Kmer>(kmer: K, stranded: Strandedness) -> usize {
     // if not stranded choose lexiographically lesser of kmer and rc of kmer
     // if forward, use original kmer
     // if reverse, use rc of kmer
     let min_kmer = match stranded {
-        Stranded::Unstranded => {
+        Strandedness::Unstranded => {
             let (min_kmer, _) = kmer.min_rc_flip();
             min_kmer
         },
-        Stranded::Forward => kmer,
-        Stranded::Reverse => kmer.rc(),
+        Strandedness::Forward => kmer,
+        Strandedness::Reverse => kmer.rc(),
     };
 
     // calculate which bucket this kmer belongs to
@@ -57,18 +57,18 @@ fn bucket_flip<K: Kmer>(kmer: K, stranded: Stranded) -> usize {
     //let bucket = bucket(min_kmer);
 }
 
-fn bucket_ext_flip<K: Kmer>(kmer: K, exts: Exts, stranded: Stranded, bucket_range: Range<usize>) ->Option<(K, Exts, usize)> {
+fn bucket_ext_flip<K: Kmer>(kmer: K, exts: Exts, stranded: Strandedness, bucket_range: Range<usize>) ->Option<(K, Exts, usize)> {
     // if not stranded choose lexiographically lesser of kmer and rc of kmer
     // if forward, use original kmer
     // if reverse, use rc of kmer
     let (min_kmer, flip_exts) = match stranded {
-        Stranded::Unstranded => {
+        Strandedness::Unstranded => {
             let (min_kmer, flip) = kmer.min_rc_flip();
             let flip_exts = if flip { exts.rc() } else { exts };
             (min_kmer, flip_exts)
         },
-        Stranded::Forward => (kmer, exts),
-        Stranded::Reverse => (kmer.rc(), exts.rc()),
+        Strandedness::Forward => (kmer, exts),
+        Strandedness::Reverse => (kmer.rc(), exts.rc()),
     };
 
     // calculate which bucket this kmer belongs to
@@ -860,7 +860,7 @@ mod tests {
             (DnaString::from_dna_string("AAAAAAAAAAAAA"), Exts::empty(), 7u8),
         ];
 
-        let mut reads = Reads::new(crate::reads::Stranded::Unstranded);
+        let mut reads = Reads::new(crate::reads::Strandedness::Unstranded);
 
         for (read, exts, data) in fastq {
             reads.add_read(read, exts, data);
@@ -898,7 +898,7 @@ mod tests {
 
         } */
 
-        let mut reads = Reads::new(crate::reads::Stranded::Unstranded);
+        let mut reads = Reads::new(crate::reads::Strandedness::Unstranded);
 
         for _i in 0..10000 {
             let dna = random_dna(150);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,6 +3,7 @@
 //! Methods for converting sequences into kmers, filtering observed kmers before De Bruijn graph construction, and summarizing 'color' annotations.
 
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
@@ -528,7 +529,7 @@ pub fn filter_kmers_parallel<K: Kmer + Sync + Send, SD: Clone + std::fmt::Debug 
 /// );
 /// ```
 #[inline(never)]
-pub fn filter_kmers<SD, K: Kmer, D1: Copy + Clone + Debug>(
+pub fn filter_kmers<SD, K: Kmer, D1: Copy + Clone + Debug + Hash + Eq>(
     seqs: &ReadsPaired<D1>,
     summary_config: &SummaryConfig,
     report_all_kmers: bool,

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -562,14 +562,14 @@ impl<D: Clone + Copy + Eq + Hash> ReadsPaired<D> {
 }
 
 impl ReadsPaired<u8> {
-    pub fn tag_kmers(&self, k: usize) -> Vec<usize>{
+    pub fn tag_kmers(&self, k: usize) -> Vec<u64>{
         let hashed_kmer_counts = self.data_kmers(k);
 
         let n_samples = hashed_kmer_counts.keys().max().expect("Error: no samples");
 
         let mut kmer_counts = vec![0; *n_samples as usize + 1];
         for (tag, kmer_count) in hashed_kmer_counts {
-            kmer_counts[tag as usize] += kmer_count;
+            kmer_counts[tag as usize] += kmer_count as u64;
         }
 
         kmer_counts

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -10,7 +10,7 @@ use crate::dna_string::DnaString;
 use crate::{base_to_bits, base_to_bits_checked, Exts, Vmer};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
-pub enum Stranded {
+pub enum Strandedness {
     Forward,
     Reverse,
     Unstranded
@@ -33,13 +33,13 @@ pub struct Reads<D> {
     exts: Vec<Exts>,
     data: Vec<D>,
     len: usize,
-    stranded: Stranded
+    stranded: Strandedness
 }
 
 impl<D: Clone + Copy> Reads<D> {
 
     /// Returns a new `Reads`
-    pub fn new(stranded: Stranded) -> Self {
+    pub fn new(stranded: Strandedness) -> Self {
         Reads {
             storage: Vec::new(),
             ends: Vec::new(),
@@ -51,7 +51,7 @@ impl<D: Clone + Copy> Reads<D> {
     }
 
     #[inline(always)]
-    pub fn stranded(&self) -> Stranded {
+    pub fn stranded(&self) -> Strandedness {
         self.stranded
     }
 
@@ -79,7 +79,7 @@ impl<D: Clone + Copy> Reads<D> {
 
     /// Transforms a `[(vmer, exts, data)]` into a `Reads` - watch for memory usage
     // TODO test if memory efficient
-    pub fn from_vmer_vec<V: Vmer, S: IntoIterator<Item=(V, Exts, D)>>(vec_iter: S, stranded: Stranded) -> Self {
+    pub fn from_vmer_vec<V: Vmer, S: IntoIterator<Item=(V, Exts, D)>>(vec_iter: S, stranded: Strandedness) -> Self {
         let mut reads = Reads::new(stranded);
         for (vmer, exts, data) in vec_iter {
             for base in vmer.iter() {
@@ -271,7 +271,7 @@ impl<D: Clone + Copy> Reads<D> {
     }
 
     /// get the `i`th read in a `Reads`
-    pub fn get_read(&self, i: usize) -> Option<(DnaString, Exts, D, Stranded)> {
+    pub fn get_read(&self, i: usize) -> Option<(DnaString, Exts, D, Strandedness)> {
         if i >= self.n_reads() { return None }
 
         let mut sequence = DnaString::new();
@@ -356,7 +356,7 @@ impl<D: Clone + Copy + Eq + Hash> Reads<D> {
 
 impl<D: Clone + Copy> Default for Reads<D> {
     fn default() -> Self {
-        Self::new(Stranded::Unstranded)
+        Self::new(Strandedness::Unstranded)
     }
 }
 
@@ -369,7 +369,7 @@ pub struct ReadsIter<'a, D> {
 }
 
 impl<D: Clone + Copy> Iterator for ReadsIter<'_, D> {
-    type Item = (DnaString, Exts, D, Stranded);
+    type Item = (DnaString, Exts, D, Strandedness);
 
     fn next(&mut self) -> Option<Self::Item> {
         if (self.i < self.reads.n_reads()) && (self.i < self.end) {
@@ -390,7 +390,7 @@ impl<D: Copy> ExactSizeIterator for ReadsIter<'_, D> {
 
 impl<D: Clone + Copy + Debug> Display for Reads<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let vec: Vec<(DnaString, Exts, D, Stranded)> = self.iter().collect();
+        let vec: Vec<(DnaString, Exts, D, Strandedness)> = self.iter().collect();
         write!(f, "{:?}", vec)
     }
 }
@@ -454,7 +454,7 @@ impl<D: Clone + Copy> ReadsPaired<D> {
         }
     }
 
-    pub fn iter(&self) -> Box<dyn Iterator<Item = (DnaString, Exts, D, Stranded)> + '_> {
+    pub fn iter(&self) -> Box<dyn Iterator<Item = (DnaString, Exts, D, Strandedness)> + '_> {
         match self {
             ReadsPaired::Empty => panic!("Error: no reads to process"),
             ReadsPaired::Unpaired { reads } => Box::new(reads.iter()),
@@ -463,7 +463,7 @@ impl<D: Clone + Copy> ReadsPaired<D> {
         }
     }
 
-    pub fn iter_partial(&self, range: Range<usize>) -> Box<dyn Iterator<Item = (DnaString, Exts, D, Stranded)> + '_> {
+    pub fn iter_partial(&self, range: Range<usize>) -> Box<dyn Iterator<Item = (DnaString, Exts, D, Strandedness)> + '_> {
         match self {
             Self::Empty => panic!("Error: no reads to process"),
             Self::Unpaired { reads } => Box::new(reads.partial_iter(range)),
@@ -594,7 +594,7 @@ mod tests {
     use itertools::enumerate;
     use rand::random;
 
-    use crate::{dna_string::DnaString, reads::Stranded, Exts};
+    use crate::{dna_string::DnaString, reads::Strandedness, Exts};
     use super::{Reads, ReadsPaired};
 
     #[test]
@@ -612,7 +612,7 @@ mod tests {
         ];
 
 
-        let mut reads = Reads::new(Stranded::Unstranded);
+        let mut reads = Reads::new(Strandedness::Unstranded);
         for (read, ext, data) in fastq.clone() {
             reads.add_read(read, ext, data);
         }
@@ -628,7 +628,7 @@ mod tests {
 
         for (i, _) in fastq.iter().enumerate() {
             //println!("read {}: {:?}", i, reads.get_read(i))
-            assert_eq!((fastq[i].0.clone(), fastq[i].1, fastq[i].2, Stranded::Unstranded), reads.get_read(i).unwrap())
+            assert_eq!((fastq[i].0.clone(), fastq[i].1, fastq[i].2, Strandedness::Unstranded), reads.get_read(i).unwrap())
         }
 
         for (seq, _, _, _) in reads.iter() {
@@ -645,7 +645,7 @@ mod tests {
 
     #[test]
     fn test_get_read() {
-        let mut reads = Reads::new(Stranded::Unstranded);
+        let mut reads = Reads::new(Strandedness::Unstranded);
         //reads.add_read(DnaString::from_acgt_bytes("AGCTAGCTAGC".as_bytes()), Exts::empty(), 67u8);
         reads.add_from_bytes("ACGATCGNATGCTAGCTGATCGGCGACGATCGATGCTAGCTGATCGTAGCTGACTGATCGATCG".as_bytes(), Exts::empty(), 67u8);
         let read = reads.get_read(0);
@@ -667,7 +667,7 @@ mod tests {
             "ACGATCGATGCTAGCTGATCGGCGACGATCGATGCTAGCTGATCGTAGCTGACTGATCGATCGAAGGGCAGTTAGGCCGTAAGCGCGAT".as_bytes(),
         ];
 
-        let mut reads: Reads<u8> = Reads::new(Stranded::Unstranded);
+        let mut reads: Reads<u8> = Reads::new(Strandedness::Unstranded);
         for seq in dna {
             reads.add_from_bytes(seq, Exts::empty(), random());
 
@@ -695,7 +695,7 @@ mod tests {
             "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN".as_bytes(),
         ];
 
-        let mut reads: Reads<u8> = Reads::new(Stranded::Unstranded);
+        let mut reads: Reads<u8> = Reads::new(Strandedness::Unstranded);
         let mut corrects = Vec::new();
         for seq in dna {
             corrects.push(reads.add_from_bytes_checked(seq, Exts::empty(), random()));
@@ -742,7 +742,7 @@ mod tests {
 
 
         let ds_start= time::Instant::now();
-        let mut reads: Reads<u8> = Reads::new(Stranded::Unstranded);
+        let mut reads: Reads<u8> = Reads::new(Strandedness::Unstranded);
         for _i in 0..REPS {
             for dna in dnas {
                 reads.add_read(DnaString::from_acgt_bytes(dna), Exts::empty(), random());
@@ -751,7 +751,7 @@ mod tests {
         let ds_finish = ds_start.elapsed();
 
         let r_start= time::Instant::now();
-        let mut reads: Reads<u8> = Reads::new(Stranded::Unstranded);
+        let mut reads: Reads<u8> = Reads::new(Strandedness::Unstranded);
         for _i in 0..REPS {
             for dna in dnas {
                 reads.add_from_bytes(dna, Exts::empty(), random());
@@ -767,15 +767,15 @@ mod tests {
 
     #[test]
     fn test_reads_stranded() {
-        let reads: Reads<u8> = Reads::new(Stranded::Forward);
-        assert_eq!(reads.stranded(), Stranded::Forward);
+        let reads: Reads<u8> = Reads::new(Strandedness::Forward);
+        assert_eq!(reads.stranded(), Strandedness::Forward);
     }
 
     #[test]
     fn test_reads_paired() {
-        let mut r1 = Reads::new(Stranded::Unstranded);
-        let mut r2 = Reads::new(Stranded::Unstranded);
-        let mut up = Reads::new(Stranded::Unstranded);
+        let mut r1 = Reads::new(Strandedness::Unstranded);
+        let mut r2 = Reads::new(Strandedness::Unstranded);
+        let mut up = Reads::new(Strandedness::Unstranded);
 
         let reads_r1 = [
             "ACGATCGTACGTACGTAGCTAGCTGCTAGCTAGCTGACTGACTGA",
@@ -800,19 +800,19 @@ mod tests {
         reads_r2.iter().for_each(|read| r2.add_from_bytes(read.as_bytes(), Exts::empty(), 0u8));
         reads_up.iter().for_each(|read| up.add_from_bytes(read.as_bytes(), Exts::empty(), 0u8));
 
-        let empty: ReadsPaired<u8> = ReadsPaired::from_reads((Reads::new(Stranded::Unstranded), Reads::new(Stranded::Unstranded), Reads::new(Stranded::Unstranded)));
+        let empty: ReadsPaired<u8> = ReadsPaired::from_reads((Reads::new(Strandedness::Unstranded), Reads::new(Strandedness::Unstranded), Reads::new(Strandedness::Unstranded)));
         assert_eq!(empty, ReadsPaired::Empty);
         assert_eq!(empty.mem(), 0);
         assert_eq!(empty.n_reads(), 0);
         assert_eq!(empty.iterable(), Vec::<&Reads<u8>>::new());
 
-        let unpaired = ReadsPaired::from_reads((Reads::new(Stranded::Unstranded), Reads::new(Stranded::Unstranded), up.clone()));
+        let unpaired = ReadsPaired::from_reads((Reads::new(Strandedness::Unstranded), Reads::new(Strandedness::Unstranded), up.clone()));
         assert_eq!(ReadsPaired::Unpaired { reads: up.clone() }, unpaired);
         assert_eq!(unpaired.mem(), 148);
         assert_eq!(unpaired.n_reads(), 2);
         assert_eq!(unpaired.iterable(), vec![&up]);
 
-        let paired = ReadsPaired::from_reads((r1.clone(), r2.clone(), Reads::new(Stranded::Unstranded)));
+        let paired = ReadsPaired::from_reads((r1.clone(), r2.clone(), Reads::new(Strandedness::Unstranded)));
         assert_eq!(ReadsPaired::Paired { r1: r1.clone(), r2: r2.clone() }, paired);        
         assert_eq!(paired.mem(), 384);
         assert_eq!(paired.n_reads(), 8);
@@ -852,7 +852,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_reads_paired_panic() {
-        let mut r1 = Reads::new(Stranded::Unstranded);
+        let mut r1 = Reads::new(Strandedness::Unstranded);
 
         let reads_r1 = [
             "ACGATCGTACGTACGTAGCTAGCTGCTAGCTAGCTGACTGACTGA",
@@ -863,6 +863,6 @@ mod tests {
 
         reads_r1.iter().for_each(|read| r1.add_from_bytes(read.as_bytes(), Exts::empty(), 0u8));
 
-        let _ = ReadsPaired::from_reads((r1, Reads::new(Stranded::Unstranded), Reads::new(Stranded::Unstranded)));
+        let _ = ReadsPaired::from_reads((r1, Reads::new(Strandedness::Unstranded), Reads::new(Strandedness::Unstranded)));
     }
 }

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -502,8 +502,8 @@ impl<D: Clone + Copy> ReadsPaired<D> {
 
     /// if the `ReadsPaired` is of `Combined` type, remove the unpaired reads
     pub fn decombine(&mut self) {
-        if let Self::Combined { r1, r2, unpaired: _ } = self {
-            *self = ReadsPaired::Paired { r1: take(r1), r2: take(r2) }
+        if let Self::Combined { paired1, paired2, unpaired: _ } = self {
+            *self = ReadsPaired::Paired { paired1: take(paired1), paired2: take(paired2) }
         }
     }
 }
@@ -513,42 +513,42 @@ impl<D: Clone + Copy + Eq + Hash> ReadsPaired<D> {
         match self {
             Self::Empty => HashMap::new(),
             Self::Unpaired { reads } => reads.data_kmers(k),
-            Self::Paired { r1, r2 } => {
-                let mut hm_r1 = r1.data_kmers(k);
-                let hm_r2 = r2.data_kmers(k);
+            Self::Paired { paired1, paired2 } => {
+                let mut hm_p1 = paired1.data_kmers(k);
+                let hm_p2 = paired2.data_kmers(k);
 
-                hm_r2.into_iter().for_each(|(data, kmers)| {
-                   if let Some(count) = hm_r1.get_mut(&data) {
+                hm_p2.into_iter().for_each(|(data, kmers)| {
+                   if let Some(count) = hm_p1.get_mut(&data) {
                     *count += kmers;
                    } else {
-                    hm_r1.insert(data, kmers);
+                    hm_p1.insert(data, kmers);
                    }
                 });
 
-                hm_r1
+                hm_p1
             },
-            Self::Combined { r1, r2, unpaired } => {
-                let mut hm_r1 = r1.data_kmers(k);
-                let hm_r2 = r2.data_kmers(k);
+            Self::Combined { paired1, paired2, unpaired } => {
+                let mut hm_p1 = paired1.data_kmers(k);
+                let hm_p2 = paired2.data_kmers(k);
                 let hm_up = unpaired.data_kmers(k);
 
-                hm_r2.into_iter().for_each(|(data, kmers)| {
-                   if let Some(count) = hm_r1.get_mut(&data) {
+                hm_p2.into_iter().for_each(|(data, kmers)| {
+                   if let Some(count) = hm_p1.get_mut(&data) {
                     *count += kmers;
                    } else {
-                    hm_r1.insert(data, kmers);
+                    hm_p1.insert(data, kmers);
                    }
                 });
 
                 hm_up.into_iter().for_each(|(data, kmers)| {
-                    if let Some(count) = hm_r1.get_mut(&data) {
+                    if let Some(count) = hm_p1.get_mut(&data) {
                      *count += kmers;
                     } else {
-                     hm_r1.insert(data, kmers);
+                     hm_p1.insert(data, kmers);
                     }
                  });
 
-                hm_r1
+                hm_p1
             }
         }
     }
@@ -574,8 +574,8 @@ impl<D: Clone + Copy> Display for ReadsPaired<D> {
         match self {
             Self::Empty => write!(f, "empty ReadsPaired"),
             Self::Unpaired { reads } => write!(f, "unpaired ReadsPaired: \n{}", reads.info()),
-            Self::Paired { r1, r2 } => write!(f, "paired ReadsPaired: \n{}\n{}", r1.info(), r2.info()),
-            Self::Combined { r1, r2, unpaired } => write!(f, "combined ReadsPaired: \n{}\n{}\n{}", r1.info(), r2.info(), unpaired.info()),
+            Self::Paired { paired1, paired2 } => write!(f, "paired ReadsPaired: \n{}\n{}", paired1.info(), paired2.info()),
+            Self::Combined { paired1, paired2, unpaired } => write!(f, "combined ReadsPaired: \n{}\n{}\n{}", paired1.info(), paired2.info(), unpaired.info()),
         }
     }
 }

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -561,6 +561,21 @@ impl<D: Clone + Copy + Eq + Hash> ReadsPaired<D> {
     }
 }
 
+impl ReadsPaired<u8> {
+    pub fn tag_kmers(&self, k: usize) -> Vec<usize>{
+        let hashed_kmer_counts = self.data_kmers(k);
+
+        let n_samples = hashed_kmer_counts.keys().max().expect("Error: no samples");
+
+        let mut kmer_counts = vec![0; *n_samples as usize + 1];
+        for (tag, kmer_count) in hashed_kmer_counts {
+            kmer_counts[tag as usize] += kmer_count;
+        }
+
+        kmer_counts
+    }
+}
+
 impl<D: Clone + Copy> Display for ReadsPaired<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/test.rs
+++ b/src/test.rs
@@ -135,7 +135,7 @@ mod tests {
 
     use crate::compression::{compress_graph, compress_kmers_with_hash, ScmapCompress, SimpleCompress};
     use crate::graph::{self, BaseGraph};
-    use crate::reads::{Reads, Stranded};
+    use crate::reads::{Reads, Strandedness};
     use crate::{DnaBytes, Tags};
     use crate::{Dir, Exts, Kmer};
     use bimap::BiMap;
@@ -246,7 +246,7 @@ mod tests {
 
 
         let (valid_kmers, _): (BoomHashMap2<K, Exts, u32>, _) = filter::filter_kmers(
-            &crate::reads::ReadsPaired::Unpaired { reads: Reads::from_vmer_vec(seqs, Stranded::Unstranded) },
+            &crate::reads::ReadsPaired::Unpaired { reads: Reads::from_vmer_vec(seqs, Strandedness::Unstranded) },
             &config,
             stranded,
             4,
@@ -358,7 +358,7 @@ mod tests {
 
         // Check the correctness of the process_kmer_shard kmer filtering function
         let (valid_kmers, _): (BoomHashMap2<K, Exts, u32>, _) = filter::filter_kmers(
-            &crate::reads::ReadsPaired::Unpaired { reads: Reads::from_vmer_vec(seqs, Stranded::Unstranded) },
+            &crate::reads::ReadsPaired::Unpaired { reads: Reads::from_vmer_vec(seqs, Strandedness::Unstranded) },
             &config,
             stranded,
             4,
@@ -469,7 +469,7 @@ mod tests {
         for seqs in shards.into_values() {
             // Check the correctness of the process_kmer_shard kmer filtering function
             let (valid_kmers, _): (BoomHashMap2<K, Exts, u32>, _) = filter::filter_kmers(
-                &crate::reads::ReadsPaired::Unpaired { reads: Reads::from_vmer_vec(seqs, Stranded::Unstranded) },
+                &crate::reads::ReadsPaired::Unpaired { reads: Reads::from_vmer_vec(seqs, Strandedness::Unstranded) },
                 &config,
                 stranded,
                 4,
@@ -536,8 +536,8 @@ mod tests {
 
         let mut rng = rand::thread_rng();
         
-        let mut clean_seqs = Reads::new(Stranded::Unstranded);
-        let mut all_seqs = Reads::new(Stranded::Unstranded);
+        let mut clean_seqs = Reads::new(Strandedness::Unstranded);
+        let mut all_seqs = Reads::new(Strandedness::Unstranded);
 
         // Generate 5x coverage of the main sequences & add some tips
         for c in contigs {
@@ -775,7 +775,7 @@ mod tests {
             (DnaString::from_dna_string("GCGATCTAGCGGATCTGCGAGCTATGC"), Exts::empty(), 6u8),
         ];
 
-        let mut reads = Reads::new(Stranded::Unstranded);
+        let mut reads = Reads::new(Strandedness::Unstranded);
 
         for (read, exts, data) in fastq {
             reads.add_read(read, exts, data);


### PR DESCRIPTION
Add new methods for `ReadsPaired`: 
- `decombine`: removes unpaired reads if there are also paired reads
- `data_kmers` & `tag_kmers`: count the kmer per sample