### PR TITLE
New kmer sizes, edge filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debruijn"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Elena Volp <elena.volp@uni-giessen.de>"]
 license = "MIT"
 edition = '2021'

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -296,7 +296,7 @@ impl<'a, SD: SummaryData<DI> + Debug, DI> Colors<'a, SD, DI> {
 
         // set outline (eg if it is in a path)
         let prefix = if outline {
-            "black, penwidth=7, fillcolor="
+            "black, penwidth=10, fillcolor="
         } else {
             ""
         };

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -60,8 +60,9 @@ impl<'a, SD: SummaryData<DI> + Debug, DI> Colors<'a, SD, DI> {
     const P_MAX: f32 = -4.;
 
     const EDGE_WIDTH_MAX: f32 = 20.;
-    const EDGE_WIDTH_MIN: f32 = 1.;
-    const EDGE_WIDTH_DEF: f32 = 1.;
+    const EDGE_WIDTH_MIN: f32 = 3.;
+    const EDGE_WIDTH_DEF: f32 = 8.;
+
 
 
     /// Creates a new [`Colors<SD>`]. 

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -321,7 +321,7 @@ pub fn get_min_max<I: Debug, F, II, N>(iter_struct: &I, iter_value: &F) -> (Opti
 where
     F: Fn(&I) -> Box<II>,
     II: Iterator<Item = N>,
-    N: CFilter + Sum + PartialOrd + Copy + Display
+    N: CFilter
 {  
     let min_o = iter_value(iter_struct)
         .filter(|value| value.filter())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2063,30 +2063,29 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(feature = "sample128"))]
     fn test_iter_edges() {
-        let path = "test_data/400.graph.dbg";
-        let file = BufReader::with_capacity(BUF, File::open(path).unwrap());
+        use crate::{compression::uncompressed_graph, filter::filter_kmers, reads::{Reads, ReadsPaired}, summarizer::{SampleInfo, SummaryConfig, TagsData}, Exts};
 
-        let (graph, _, _): (DebruijnGraph<Kmer16, TagsCountsSumData>, Vec<String>, crate::summarizer::SummaryConfig) = 
-            bincode::deserialize_from(file).expect("error deserializing graph");
+        let read1 = "CAGCATCGATGCGACGAGCGCTCGCATCGA".as_bytes();
+        let read2 = "ACGATCGTACGTAGCTAGCTGACTGAGC".as_bytes();
 
-        let check_edges = vec![(3, Dir::Left, 2, 134), (3, Dir::Right, 2, 67), (14, Dir::Left, 0, 91), 
-            (14, Dir::Right, 0, 70), (26, Dir::Left, 2, 111), (29, Dir::Left, 1, 131), (29, Dir::Left, 3, 84), (29, Dir::Right, 1, 137), 
-            (30, Dir::Left, 3, 43), (30, Dir::Right, 2, 91), (38, Dir::Left, 3, 81), (38, Dir::Right, 1, 88), (41, Dir::Left, 0, 138), 
-            (43, Dir::Left, 0, 131), (53, Dir::Left, 0, 127), (53, Dir::Right, 1, 117), (59, Dir::Left, 3, 133), (59, Dir::Right, 0, 119), 
-            (62, Dir::Left, 3, 119), (62, Dir::Right, 3, 103), (63, Dir::Left, 1, 121), (63, Dir::Right, 0, 124), (67, Dir::Left, 3, 130), 
-            (68, Dir::Left, 0, 137), (68, Dir::Right, 3, 110), (69, Dir::Left, 1, 114), (69, Dir::Left, 3, 77), (69, Dir::Right, 1, 144), 
-            (70, Dir::Right, 0, 79), (75, Dir::Left, 2, 121), (75, Dir::Right, 2, 128), (77, Dir::Left, 1, 120), (78, Dir::Left, 2, 122), 
-            (78, Dir::Right, 2, 125), (79, Dir::Right, 2, 142), (81, Dir::Left, 0, 113), (81, Dir::Right, 0, 143), (81, Dir::Right, 3, 108), 
-            (83, Dir::Right, 3, 109), (86, Dir::Left, 1, 139), (88, Dir::Left, 0, 113), (88, Dir::Right, 3, 134), (91, Dir::Left, 3, 141), 
-            (92, Dir::Left, 3, 135), (92, Dir::Right, 0, 108), (93, Dir::Left, 0, 109), (93, Dir::Right, 0, 126), (96, Dir::Left, 0, 116), 
-            (96, Dir::Right, 0, 135), (97, Dir::Left, 1, 119), (97, Dir::Right, 0, 110), (100, Dir::Left, 2, 139), (100, Dir::Right, 0, 138), 
-            (101, Dir::Right, 0, 120), (103, Dir::Right, 3, 105), (104, Dir::Left, 3, 110), (104, Dir::Right, 2, 119), (105, Dir::Right, 0, 136), 
-            (106, Dir::Left, 3, 124), (106, Dir::Right, 3, 129), (107, Dir::Right, 0, 120), (111, Dir::Right, 2, 140), (112, Dir::Left, 2, 115), 
-            (112, Dir::Left, 3, 118), (112, Dir::Right, 0, 124), (114, Dir::Left, 1, 120), (115, Dir::Right, 0, 123), (116, Dir::Left, 2, 121), 
-            (118, Dir::Right, 0, 123), (121, Dir::Right, 2, 132), (123, Dir::Right, 0, 125), (126, Dir::Right, 0, 132), (128, Dir::Left, 1, 140), 
-            (129, Dir::Right, 0, 132), (130, Dir::Left, 0, 133), (136, Dir::Right, 3, 142), (138, Dir::Left, 0, 138), (139, Dir::Left, 1, 139)];
+        let mut reads = Reads::new(crate::reads::Strandedness::Forward);
+        reads.add_from_bytes(read1, Exts::empty(), 0u8);
+        reads.add_from_bytes(read2, Exts::empty(), 1);
+
+        let reads_paired = ReadsPaired::Unpaired { reads };
+
+        let sample_info = SampleInfo::new(0b1, 0b10, 1, 1, vec![12, 12]);
+        let summary_config = SummaryConfig::new(1, None, crate::summarizer::GroupFrac::None, 0.3, sample_info, None, crate::summarizer::StatTest::WelchsTTest);
+        let (kmers, _) = filter_kmers::<TagsData, Kmer16, _>(&reads_paired, &summary_config, false, 1, false);
+
+        let graph = uncompressed_graph(&kmers).finish();
+
+        let check_edges: Vec<(usize, Dir, u8, usize)> = vec![(0, Dir::Left, 2, 16), (0, Dir::Right, 1, 2), (1, Dir::Left, 0, 11), 
+        (1, Dir::Right, 0, 16), (3, Dir::Left, 0, 13), (3, Dir::Right, 3, 10), (4, Dir::Left, 2, 21), (4, Dir::Right, 1, 17), (5, Dir::Left, 1, 27), 
+        (5, Dir::Right, 2, 19), (6, Dir::Left, 1, 24), (6, Dir::Right, 2, 12), (7, Dir::Left, 2, 23), (7, Dir::Right, 3, 11), (8, Dir::Left, 0, 12), 
+        (9, Dir::Left, 3, 17), (9, Dir::Right, 3, 24), (10, Dir::Right, 1, 21), (13, Dir::Left, 1, 18), (14, Dir::Right, 0, 26), 
+        (15, Dir::Left, 2, 20), (15, Dir::Right, 3, 22), (18, Dir::Left, 2, 19), (20, Dir::Left, 1, 26), (22, Dir::Right, 2, 25), (23, Dir::Left, 1, 25)];
 
         let edges = graph.iter_edges().collect::<Vec<_>>();
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1890,15 +1890,12 @@ F2: Fn(&D) -> bool
                                     next = cand;
                                 }
                             }
-    
-                            /* if oscore(cand) > oscore(next) {
-                                next = cand;
-                            } */
                         }
-    
-                        if solid_paths > 1 {
+                        
+                        // break if multiple solid paths are available
+                        /* if solid_paths > 1 {
                             break;
-                        }
+                        } */
     
                         match next {
                             Some((next_id, next_incoming)) if !used_nodes.contains(&next_id) => {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -727,8 +727,8 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
     /// ### Arguments: 
     /// 
     /// * `path`: path to the output file
-    /// * `node_label`: closure taking [`Node<K, D>`] and returning a string containing commands for dot nodes 
-    /// * `edge_label`: closure taking [`Node<K, D>`], the base as a [`u8`], the incoming [`Dir`] of the edge 
+    /// * `node_label`: closure taking [`Node<K, D>`] and returning a string containing commands for dot nodes, e.g. [`Node::node_dot_default`]
+    /// * `edge_label`: closure taking [`Node<K, D>`], the base as a [`u8`], the incoming [`Dir`] of the edge, e.g. [`Node::edge_dot_default`]
     ///    and if the neighbor is flipped - returns a string containing commands for dot edges, 
     pub fn to_dot<P, FN, FE>(&self, path: P, node_label: &FN, edge_label: &FE) 
     where 
@@ -746,6 +746,48 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         for i in (0..self.len()).progress_with(pb) {
             self.node_to_dot(&self.get_node(i), node_label, edge_label, &mut f);
         }
+        writeln!(&mut f, "}}").unwrap();
+        
+        f.flush().unwrap();
+        debug!("large to dot loop: {}", self.len());
+    }
+
+    /// Write the graph to a dot file, highlight the nodes which form the 
+    /// "best" path, according to [`PathCompIter`], with the number of occurences 
+    /// as the score and `solid_path` always `true`.
+    /// The nodes are formatted according to [`Node::node_dot_default`].
+    /// 
+    /// ### Arguments: 
+    /// 
+    /// * `path`: path to the output file
+    /// * `edge_label`: closure taking [`Node<K, D>`], the base as a [`u8`], the incoming [`Dir`] of the edge, e.g. [`Node::edge_dot_default`]
+    ///    and if the neighbor is flipped - returns a string containing commands for dot edges, 
+    /// * `colors`: a [`Colors`] with the color settings for the graph
+    /// * `translator`: a [`Translator`] which translates tags or IDs to strings
+    /// * `config`: a [`SummaryConfig`] which contains settings for the graph
+    pub fn to_dot_with_path<P, FE, DI>(&self, path: P, edge_label: &FE, colors: &Colors<'_, D, DI>, translator: &Translator, config: &SummaryConfig)
+    where 
+    P: AsRef<Path>,
+    D: SummaryData<DI>,
+    FE: Fn(&Node<K, D>, u8, Dir, bool) -> String,
+    {
+        let mut f = BufWriter::with_capacity(BUF, File::create(path).expect("error creating dot file"));
+
+        writeln!(&mut f, "digraph {{\nrankdir=\"LR\"\nmodel=subset\noverlap=scalexy").unwrap();
+
+        // iterate over components
+        for (component, path) in self.iter_max_path_comp(|d| d.sum().unwrap_or(1) as f32, |_| true) {
+            let hashed_path = path.into_iter().map(|(id, _)| id).collect::<HashSet<usize>>();
+            for node_id in component {
+                self.node_to_dot(
+                    &self.get_node(node_id),
+                    &|node| node.node_dot_default(colors, config, translator, hashed_path.contains(&node_id)), 
+                    edge_label, 
+                    &mut f
+                );
+            }
+        }
+
         writeln!(&mut f, "}}").unwrap();
         
         f.flush().unwrap();
@@ -839,6 +881,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
 
 
     }
+
 
     /// Write part of the graph to a dot file
     /// 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1700,7 +1700,7 @@ impl<K: Kmer, SD: Debug> Node<'_, K, SD>  {
 
             format!("[color={color}, penwidth={penwidth}, label=\"{}: {count}\"]", bits_to_base(base))
         } else {
-            format!("[color={color}]")
+            format!("[color={color}, penwidth={}]", colors.edge_width(1)) // since there should be no edge mults, this will return default value
         }
     }
 
@@ -1848,9 +1848,9 @@ F2: Fn(&D) -> bool
                                 }
                             }
     
-                            if oscore(cand) > oscore(next) {
+                            /* if oscore(cand) > oscore(next) {
                                 next = cand;
-                            }
+                            } */
                         }
     
                         if solid_paths > 1 {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -14,6 +14,7 @@ use serde_derive::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::f32;
@@ -40,6 +41,7 @@ use crate::colors::ColorMode;
 use crate::colors::Colors;
 use crate::compression::CompressionSpec;
 use crate::dna_string::{DnaString, DnaStringSlice, PackedDnaStringSet};
+use crate::graph;
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
 use crate::summarizer::Translator;
@@ -1391,6 +1393,10 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         comp
     }
 
+    pub fn iter_edges(&self) -> EdgeIter<'_, K, D> {
+        EdgeIter::new(self)
+    }
+
     pub fn find_bad_nodes<F: Fn(&Node<'_, K, D>) -> bool>(&self, valid: F) -> Vec<usize> {
         let mut bad_nodes = Vec::new();
 
@@ -1885,6 +1891,93 @@ F2: Fn(&D) -> bool
     }
 }
 
+
+pub struct EdgeIter<'a, K: Kmer, D: Debug> {
+    graph: &'a DebruijnGraph<K, D>,
+    visited_edges: HashSet<(usize, usize)>,
+    current_node: usize,
+    current_dir: Dir,
+    node_edge_iter: smallvec::IntoIter<[(u8, usize, Dir, bool); 4]>
+}
+
+impl<K: Kmer, D: Debug> EdgeIter<'_, K, D> {
+    pub fn new(graph: &DebruijnGraph<K, D>) -> EdgeIter<'_, K, D>{
+        let node_edge_iter = graph.get_node(0).l_edges().into_iter();
+
+        EdgeIter { 
+            graph, 
+            visited_edges: HashSet::new(), 
+            current_node: 0, 
+            current_dir: Dir::Left, 
+            node_edge_iter
+        }
+    }
+}
+
+impl<K: Kmer, D: Debug> Iterator for EdgeIter<'_, K, D> {
+    type Item = (usize, Dir, u8, usize); // node, direction leaving node, base, target node
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+/*             match self.current_dir {
+                Dir::Left => {
+                    if let Some((_, nb_node_id, _, _)) = self.node_edge_iter.next() {
+                        let edge = if self.current_node > nb_node_id { (nb_node_id, self.current_node) } else { (self.current_node, nb_node_id) };
+
+                        if self.visited_edges.insert(edge) { return Some(edge); } // else simply skip and move on
+
+                    } else {
+                        self.current_dir = Dir::Right;
+                        self.node_edge_iter = self.graph.get_node(self.current_node).r_edges().into_iter();
+                    }
+                }
+                Dir::Right => {
+                    if let Some((_, nb_node_id, _, _)) = self.node_edge_iter.next() {
+                        let edge = if self.current_node > nb_node_id { (nb_node_id, self.current_node) } else { (self.current_node, nb_node_id) };
+
+                        if self.visited_edges.insert(edge) { return Some(edge); } // else simply skip and move on
+
+                    } else {
+                        self.current_node += 1;
+                        if self.current_node == self.graph.len() - 1 {
+                            return None
+                        }
+                        self.current_dir = Dir::Left;
+                        self.node_edge_iter = self.graph.get_node(self.current_node).l_edges().into_iter();
+                    }
+                }
+            } */
+
+            if let Some((base, nb_node_id, _, _)) = self.node_edge_iter.next() {
+                let edge = if self.current_node > nb_node_id { (nb_node_id, self.current_node) } else { (self.current_node, nb_node_id) };
+
+                if self.visited_edges.insert(edge) { return Some((self.current_node, self.current_dir, base, nb_node_id)); } // else simply skip and move on
+
+            } else {
+                match self.current_dir {
+                Dir::Left => {
+                    // no left edges, switch to right edges
+                    self.current_dir = Dir::Right;
+                    self.node_edge_iter = self.graph.get_node(self.current_node).r_edges().into_iter();
+                    
+                }
+                Dir::Right => {
+                    // no right edges, switch to next node left edges
+                    self.current_node += 1;
+
+                    // quit if end of graph is reached
+                    if self.current_node == self.graph.len() { return None }
+
+                    self.current_dir = Dir::Left;
+                    self.node_edge_iter = self.graph.get_node(self.current_node).l_edges().into_iter();
+                }
+            }
+            }
+            
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::{fs::File, io::BufReader};
@@ -1892,11 +1985,12 @@ mod test {
     use crate::{kmer::Kmer16, summarizer::TagsCountsSumData};
 
     use super::DebruijnGraph;
+    use crate::{summarizer::SummaryData, Dir, BUF};
+
 
     #[test]
     #[cfg(not(feature = "sample128"))]
     fn test_components() {
-        use crate::{summarizer::SummaryData, Dir, BUF};
 
         let path = "test_data/400.graph.dbg";
         let file = BufReader::with_capacity(BUF, File::open(path).unwrap());
@@ -1925,6 +2019,36 @@ mod test {
             }
         }
         assert_eq!(vec![(139, Dir::Left)], graph.max_path(|data| data.sum().unwrap_or(1) as f32, |_| true));
+    }
+
+    #[test]
+    fn test_iter_edges() {
+        let path = "test_data/400.graph.dbg";
+        let file = BufReader::with_capacity(BUF, File::open(path).unwrap());
+
+        let (graph, _, _): (DebruijnGraph<Kmer16, TagsCountsSumData>, Vec<String>, crate::summarizer::SummaryConfig) = 
+            bincode::deserialize_from(file).expect("error deserializing graph");
+
+        let check_edges = vec![(3, Dir::Left, 2, 134), (3, Dir::Right, 2, 67), (14, Dir::Left, 0, 91), 
+            (14, Dir::Right, 0, 70), (26, Dir::Left, 2, 111), (29, Dir::Left, 1, 131), (29, Dir::Left, 3, 84), (29, Dir::Right, 1, 137), 
+            (30, Dir::Left, 3, 43), (30, Dir::Right, 2, 91), (38, Dir::Left, 3, 81), (38, Dir::Right, 1, 88), (41, Dir::Left, 0, 138), 
+            (43, Dir::Left, 0, 131), (53, Dir::Left, 0, 127), (53, Dir::Right, 1, 117), (59, Dir::Left, 3, 133), (59, Dir::Right, 0, 119), 
+            (62, Dir::Left, 3, 119), (62, Dir::Right, 3, 103), (63, Dir::Left, 1, 121), (63, Dir::Right, 0, 124), (67, Dir::Left, 3, 130), 
+            (68, Dir::Left, 0, 137), (68, Dir::Right, 3, 110), (69, Dir::Left, 1, 114), (69, Dir::Left, 3, 77), (69, Dir::Right, 1, 144), 
+            (70, Dir::Right, 0, 79), (75, Dir::Left, 2, 121), (75, Dir::Right, 2, 128), (77, Dir::Left, 1, 120), (78, Dir::Left, 2, 122), 
+            (78, Dir::Right, 2, 125), (79, Dir::Right, 2, 142), (81, Dir::Left, 0, 113), (81, Dir::Right, 0, 143), (81, Dir::Right, 3, 108), 
+            (83, Dir::Right, 3, 109), (86, Dir::Left, 1, 139), (88, Dir::Left, 0, 113), (88, Dir::Right, 3, 134), (91, Dir::Left, 3, 141), 
+            (92, Dir::Left, 3, 135), (92, Dir::Right, 0, 108), (93, Dir::Left, 0, 109), (93, Dir::Right, 0, 126), (96, Dir::Left, 0, 116), 
+            (96, Dir::Right, 0, 135), (97, Dir::Left, 1, 119), (97, Dir::Right, 0, 110), (100, Dir::Left, 2, 139), (100, Dir::Right, 0, 138), 
+            (101, Dir::Right, 0, 120), (103, Dir::Right, 3, 105), (104, Dir::Left, 3, 110), (104, Dir::Right, 2, 119), (105, Dir::Right, 0, 136), 
+            (106, Dir::Left, 3, 124), (106, Dir::Right, 3, 129), (107, Dir::Right, 0, 120), (111, Dir::Right, 2, 140), (112, Dir::Left, 2, 115), 
+            (112, Dir::Left, 3, 118), (112, Dir::Right, 0, 124), (114, Dir::Left, 1, 120), (115, Dir::Right, 0, 123), (116, Dir::Left, 2, 121), 
+            (118, Dir::Right, 0, 123), (121, Dir::Right, 2, 132), (123, Dir::Right, 0, 125), (126, Dir::Right, 0, 132), (128, Dir::Left, 1, 140), 
+            (129, Dir::Right, 0, 132), (130, Dir::Left, 0, 133), (136, Dir::Right, 3, 142), (138, Dir::Left, 0, 138), (139, Dir::Left, 1, 139)];
+
+        let edges = graph.iter_edges().collect::<Vec<_>>();
+
+        assert_eq!(check_edges, edges);
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1393,6 +1393,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         comp
     }
 
+    /// iterate over all edges of the graph, item: (node, ext base, ext dir, target node)
     pub fn iter_edges(&self) -> EdgeIter<'_, K, D> {
         EdgeIter::new(self)
     }
@@ -1892,6 +1893,7 @@ F2: Fn(&D) -> bool
 }
 
 
+/// iterator over the edges of the de bruijn graph
 pub struct EdgeIter<'a, K: Kmer, D: Debug> {
     graph: &'a DebruijnGraph<K, D>,
     visited_edges: HashSet<(usize, usize)>,
@@ -1919,35 +1921,6 @@ impl<K: Kmer, D: Debug> Iterator for EdgeIter<'_, K, D> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-/*             match self.current_dir {
-                Dir::Left => {
-                    if let Some((_, nb_node_id, _, _)) = self.node_edge_iter.next() {
-                        let edge = if self.current_node > nb_node_id { (nb_node_id, self.current_node) } else { (self.current_node, nb_node_id) };
-
-                        if self.visited_edges.insert(edge) { return Some(edge); } // else simply skip and move on
-
-                    } else {
-                        self.current_dir = Dir::Right;
-                        self.node_edge_iter = self.graph.get_node(self.current_node).r_edges().into_iter();
-                    }
-                }
-                Dir::Right => {
-                    if let Some((_, nb_node_id, _, _)) = self.node_edge_iter.next() {
-                        let edge = if self.current_node > nb_node_id { (nb_node_id, self.current_node) } else { (self.current_node, nb_node_id) };
-
-                        if self.visited_edges.insert(edge) { return Some(edge); } // else simply skip and move on
-
-                    } else {
-                        self.current_node += 1;
-                        if self.current_node == self.graph.len() - 1 {
-                            return None
-                        }
-                        self.current_dir = Dir::Left;
-                        self.node_edge_iter = self.graph.get_node(self.current_node).l_edges().into_iter();
-                    }
-                }
-            } */
-
             if let Some((base, nb_node_id, _, _)) = self.node_edge_iter.next() {
                 let edge = if self.current_node > nb_node_id { (nb_node_id, self.current_node) } else { (self.current_node, nb_node_id) };
 
@@ -2022,6 +1995,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(feature = "sample128"))]
     fn test_iter_edges() {
         let path = "test_data/400.graph.dbg";
         let file = BufReader::with_capacity(BUF, File::open(path).unwrap());

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -14,7 +14,6 @@ use serde_derive::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::f32;
@@ -41,7 +40,6 @@ use crate::colors::ColorMode;
 use crate::colors::Colors;
 use crate::compression::CompressionSpec;
 use crate::dna_string::{DnaString, DnaStringSlice, PackedDnaStringSet};
-use crate::graph;
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
 use crate::summarizer::Translator;
@@ -1460,7 +1458,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         Colors::new(self, config, color_mode)
     }
     
-    /// edge mults will contain hanging edges if the nodes were filtered
+    /// [`crate::EdgeMult`] will contain hanging edges if the nodes were filtered
     pub fn fix_edge_mults<DI>(&mut self) 
     where 
         SD: SummaryData<DI>
@@ -1472,7 +1470,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         }
     }
 
-    /// if there are edge mults in the data, prune the graph by removing edges that have a low coverage
+    /// if there are [`crate::EdgeMult`]s in the data, prune the graph by removing edges that have a low coverage
     pub fn filter_edges<DI>(&mut self, min: u32) -> Result<(), String>
     where 
         SD: SummaryData<DI>

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1471,6 +1471,30 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
         }
     }
+
+    /// if there are edge mults in the data, prune the graph by removing edges that have a low coverage
+    pub fn filter_edges<DI>(&mut self, min: u32)
+    where 
+        SD: SummaryData<DI>
+    {
+        // return if there is no edge coverage available
+        if self.get_node(0).data().edge_mults().is_none() { return };
+
+        for i in 0..self.len() {
+            let em = self.get_node(i).data().edge_mults().expect("shold have em").clone();
+            
+            for (dir, base) in [(Dir::Left, 0), (Dir::Left, 1), (Dir::Left, 2), (Dir::Left, 3), (Dir::Right, 0), (Dir::Right, 1), (Dir::Right, 2), (Dir::Right, 3)] {
+                if min > em.edge_mult(base, dir) {
+                    // remove invalid ext from node
+                    let ext = self.base.exts[i].remove(dir, base);
+                    self.base.exts[i] = ext;
+                }
+            }
+        }
+
+        // now that exts are remove, fix hanging edge mults
+        self.fix_edge_mults();
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1473,17 +1473,19 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     }
 
     /// if there are edge mults in the data, prune the graph by removing edges that have a low coverage
-    pub fn filter_edges<DI>(&mut self, min: u32)
+    pub fn filter_edges<DI>(&mut self, min: u32) -> Result<(), String>
     where 
         SD: SummaryData<DI>
     {
         // return if there is no edge coverage available
-        if self.get_node(0).data().edge_mults().is_none() { return };
+        if self.get_node(0).data().edge_mults().is_none() { return Err(String::from("no edge mults available")) };
 
         for i in 0..self.len() {
             let em = self.get_node(i).data().edge_mults().expect("shold have em").clone();
+            let edges = [(Dir::Left, 0), (Dir::Left, 1), (Dir::Left, 2), (Dir::Left, 3), 
+                (Dir::Right, 0), (Dir::Right, 1), (Dir::Right, 2), (Dir::Right, 3)];
             
-            for (dir, base) in [(Dir::Left, 0), (Dir::Left, 1), (Dir::Left, 2), (Dir::Left, 3), (Dir::Right, 0), (Dir::Right, 1), (Dir::Right, 2), (Dir::Right, 3)] {
+            for (dir, base) in edges {
                 if min > em.edge_mult(base, dir) {
                     // remove invalid ext from node
                     let ext = self.base.exts[i].remove(dir, base);
@@ -1494,6 +1496,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
         // now that exts are remove, fix hanging edge mults
         self.fix_edge_mults();
+
+        Ok(())
     }
 }
 

--- a/src/kmer.rs
+++ b/src/kmer.rs
@@ -1945,6 +1945,27 @@ mod tests {
     }
 
     #[test]
+    fn test_kmer_19() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u64, K19>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_18() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u64, K18>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_17() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u64, K17>>();
+        }
+    }
+
+    #[test]
     fn test_kmer_16() {
         for _ in 0..10000 {
             check_kmer::<IntKmer<u32>>();
@@ -1966,9 +1987,23 @@ mod tests {
     }
 
     #[test]
+    fn test_kmer_13() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u32, K13>>();
+        }
+    }
+
+    #[test]
     fn test_kmer_12() {
         for _ in 0..10000 {
             check_kmer::<VarIntKmer<u32, K12>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_11() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u32, K11>>();
         }
     }
 
@@ -1980,9 +2015,23 @@ mod tests {
     }
 
     #[test]
+    fn test_kmer_9() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u32, K9>>();
+        }
+    }
+
+    #[test]
     fn test_kmer_8() {
         for _ in 0..10000 {
             check_kmer::<IntKmer<u16>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_7() {
+        for _ in 0..10000 {
+            check_kmer::<Kmer7>();
         }
     }
 
@@ -2004,6 +2053,20 @@ mod tests {
     fn test_kmer_4() {
         for _ in 0..10000 {
             check_kmer::<Kmer4>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_3() {
+        for _ in 0..10000 {
+            check_kmer::<Kmer3>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_2() {
+        for _ in 0..10000 {
+            check_kmer::<Kmer2>();
         }
     }
 }

--- a/src/kmer.rs
+++ b/src/kmer.rs
@@ -49,76 +49,131 @@ use crate::Mer;
 
 /// 64-base kmer, backed by a single u128
 pub type Kmer64 = IntKmer<u128>;
-
+/// 63-base kmer, backed by a single u128
+pub type Kmer63 = VarIntKmer<u128, K63>;
+/// 62-base kmer, backed by a single u128
+pub type Kmer62 = VarIntKmer<u128, K62>;
+/// 61-base kmer, backed by a single u128
+pub type Kmer61 = VarIntKmer<u128, K61>;
+/// 60-base kmer, backed by a single u128
+pub type Kmer60 = VarIntKmer<u128, K60>;
+/// 59-base kmer, backed by a single u128
+pub type Kmer59 = VarIntKmer<u128, K59>;
+/// 58-base kmer, backed by a single u128
+pub type Kmer58 = VarIntKmer<u128, K58>;
+/// 57-base kmer, backed by a single u128
+pub type Kmer57 = VarIntKmer<u128, K57>;
+/// 56-base kmer, backed by a single u128
+pub type Kmer56 = VarIntKmer<u128, K56>;
+/// 55-base kmer, backed by a single u128
+pub type Kmer55 = VarIntKmer<u128, K55>;
+/// 54-base kmer, backed by a single u128
+pub type Kmer54 = VarIntKmer<u128, K54>;
+/// 53-base kmer, backed by a single u128
+pub type Kmer53 = VarIntKmer<u128, K53>;
+/// 52-base kmer, backed by a single u128
+pub type Kmer52 = VarIntKmer<u128, K52>;
+/// 51-base kmer, backed by a single u128
+pub type Kmer51 = VarIntKmer<u128, K51>;
+/// 50-base kmer, backed by a single u128
+pub type Kmer50 = VarIntKmer<u128, K50>;
+/// 49-base kmer, backed by a single u128
+pub type Kmer49 = VarIntKmer<u128, K49>;
 /// 48-base kmer, backed by a single u128
 pub type Kmer48 = VarIntKmer<u128, K48>;
-
+/// 47-base kmer, backed by a single u128
+pub type Kmer47 = VarIntKmer<u128, K47>;
+/// 46-base kmer, backed by a single u128
+pub type Kmer46 = VarIntKmer<u128, K46>;
+/// 45-base kmer, backed by a single u128
+pub type Kmer45 = VarIntKmer<u128, K45>;
+/// 44-base kmer, backed by a single u128
+pub type Kmer44 = VarIntKmer<u128, K44>;
+/// 43-base kmer, backed by a single u128
+pub type Kmer43 = VarIntKmer<u128, K43>;
+/// 42-base kmer, backed by a single u128
+pub type Kmer42 = VarIntKmer<u128, K42>;
+/// 41-base kmer, backed by a single u128
+pub type Kmer41 = VarIntKmer<u128, K41>;
 /// 40-base kmer, backed by a single u128
 pub type Kmer40 = VarIntKmer<u128, K40>;
-
+/// 39-base kmer, backed by a single u128
+pub type Kmer39 = VarIntKmer<u128, K39>;
+/// 38-base kmer, backed by a single u128
+pub type Kmer38 = VarIntKmer<u128, K38>;
+/// 37-base kmer, backed by a single u128
+pub type Kmer37 = VarIntKmer<u128, K37>;
+/// 36-base kmer, backed by a single u128
+pub type Kmer36 = VarIntKmer<u128, K36>;
+/// 35-base kmer, backed by a single u128
+pub type Kmer35 = VarIntKmer<u128, K35>;
+/// 34-base kmer, backed by a single u128
+pub type Kmer34 = VarIntKmer<u128, K34>;
+/// 33-base kmer, backed by a single u128
+pub type Kmer33 = VarIntKmer<u128, K33>;
 /// 32-base kmer, backed by a single u64
 pub type Kmer32 = IntKmer<u64>;
-
-/// 30-base kmer, backed by a single u64
+/// 31-base kmer, backed by a single u64
 pub type Kmer31 = VarIntKmer<u64, K31>;
-
 /// 30-base kmer, backed by a single u64
 pub type Kmer30 = VarIntKmer<u64, K30>;
-
 /// 29-base kmer, backed by a single u64
 pub type Kmer29 = VarIntKmer<u64, K29>;
-
 /// 28-base kmer, backed by a single u64
 pub type Kmer28 = VarIntKmer<u64, K28>;
-
 /// 27-base kmer, backed by a single u64
 pub type Kmer27 = VarIntKmer<u64, K27>;
-
-/// 26-base kmer, backed by a single u64
+/// 25-base kmer, backed by a single u64
 pub type Kmer26 = VarIntKmer<u64, K26>;
-
 /// 25-base kmer, backed by a single u64
 pub type Kmer25 = VarIntKmer<u64, K25>;
-
 /// 24-base kmer, backed by a single u64
 pub type Kmer24 = VarIntKmer<u64, K24>;
-
 /// 23-base kmer, backed by a single u64
 pub type Kmer23 = VarIntKmer<u64, K23>;
-
 /// 22-base kmer, backed by a single u64
 pub type Kmer22 = VarIntKmer<u64, K22>;
-
 /// 21-base kmer, backed by a single u64
 pub type Kmer21 = VarIntKmer<u64, K21>;
-
 /// 20-base kmer, backed by a single u64
 pub type Kmer20 = VarIntKmer<u64, K20>;
-
+/// 19-base kmer, backed by a single u64
+pub type Kmer19 = VarIntKmer<u64, K19>;
+/// 18-base kmer, backed by a single u64
+pub type Kmer18 = VarIntKmer<u64, K18>;
+/// 17-base kmer, backed by a single u64
+pub type Kmer17 = VarIntKmer<u64, K17>;
 /// 16-base kmer, backed by a single u32
 pub type Kmer16 = IntKmer<u32>;
-
 /// 15-base kmer, backed by a single u32
 pub type Kmer15 = VarIntKmer<u32, K15>;
-
 /// 14-base kmer, backed by a single u32
 pub type Kmer14 = VarIntKmer<u32, K14>;
-
+/// 13-base kmer, backed by a single u32
+pub type Kmer13 = VarIntKmer<u32, K13>;
 /// 12-base kmer, backed by a single u32
 pub type Kmer12 = VarIntKmer<u32, K12>;
-
+/// 11-base kmer, backed by a single u32
+pub type Kmer11 = VarIntKmer<u32, K11>;
 /// 10-base kmer, backed by a single u32
 pub type Kmer10 = VarIntKmer<u32, K10>;
-
+/// 9-base kmer, backed by a single u32
+pub type Kmer9 = VarIntKmer<u32, K9>;
 /// 8-base kmer, backed by a single u16
 pub type Kmer8 = IntKmer<u16>;
-
+/// 7-base kmer, backed by a single u16
+pub type Kmer7 = VarIntKmer<u16, K7>;
+/// 6-base kmer, backed by a single u16
 pub type Kmer6 = VarIntKmer<u16, K6>;
+/// 5-base kmer, backed by a single u16
 pub type Kmer5 = VarIntKmer<u16, K5>;
-
+/// 4-base kmer, backed by a single u8
 pub type Kmer4 = IntKmer<u8>;
+/// 3-base kmer, backed by a single u8
 pub type Kmer3 = VarIntKmer<u8, K3>;
+/// 2-base kmer, backed by a single u8
 pub type Kmer2 = VarIntKmer<u8, K2>;
+
 
 /// Trait for specialized integer operations used in DeBruijn Graph
 pub trait IntHelp: PrimInt + FromPrimitive {
@@ -688,6 +743,172 @@ impl<T: PrimInt + FromPrimitive + Hash + IntHelp, KS: KmerSize> fmt::Debug for V
     }
 }
 
+/// Marker struct for generating K=63 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K63;
+
+impl KmerSize for K63 {
+    #[inline(always)]
+    fn K() -> usize {
+        63
+    }
+}
+
+/// Marker struct for generating K=62 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K62;
+
+impl KmerSize for K62 {
+    #[inline(always)]
+    fn K() -> usize {
+        62
+    }
+}
+
+/// Marker struct for generating K=61 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K61;
+
+impl KmerSize for K61 {
+    #[inline(always)]
+    fn K() -> usize {
+        61
+    }
+}
+
+/// Marker struct for generating K=60 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K60;
+
+impl KmerSize for K60 {
+    #[inline(always)]
+    fn K() -> usize {
+        60
+    }
+}
+
+
+/// Marker struct for generating K=59 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K59;
+
+impl KmerSize for K59 {
+    #[inline(always)]
+    fn K() -> usize {
+        59
+    }
+}
+
+/// Marker struct for generating K=58 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K58;
+
+impl KmerSize for K58 {
+    #[inline(always)]
+    fn K() -> usize {
+        58
+    }
+}
+
+/// Marker struct for generating K=57 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K57;
+
+impl KmerSize for K57 {
+    #[inline(always)]
+    fn K() -> usize {
+        57
+    }
+}
+
+/// Marker struct for generating K=56 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K56;
+
+impl KmerSize for K56 {
+    #[inline(always)]
+    fn K() -> usize {
+        56
+    }
+}
+
+/// Marker struct for generating K=55 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K55;
+
+impl KmerSize for K55 {
+    #[inline(always)]
+    fn K() -> usize {
+        55
+    }
+}
+
+/// Marker struct for generating K=54 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K54;
+
+impl KmerSize for K54 {
+    #[inline(always)]
+    fn K() -> usize {
+        54
+    }
+}
+
+/// Marker struct for generating K=53 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K53;
+
+impl KmerSize for K53 {
+    #[inline(always)]
+    fn K() -> usize {
+        53
+    }
+}
+
+/// Marker struct for generating K=52 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K52;
+
+impl KmerSize for K52 {
+    #[inline(always)]
+    fn K() -> usize {
+        52
+    }
+}
+
+/// Marker struct for generating K=51 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K51;
+
+impl KmerSize for K51 {
+    #[inline(always)]
+    fn K() -> usize {
+        51
+    }
+}
+
+/// Marker struct for generating K=50 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K50;
+
+impl KmerSize for K50 {
+    #[inline(always)]
+    fn K() -> usize {
+        50
+    }
+}
+
+/// Marker struct for generating K=49 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K49;
+
+impl KmerSize for K49 {
+    #[inline(always)]
+    fn K() -> usize {
+        49
+    }
+}
+
 /// Marker struct for generating K=48 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K48;
@@ -699,6 +920,83 @@ impl KmerSize for K48 {
     }
 }
 
+/// Marker trait for generating K=47 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K47;
+
+impl KmerSize for K47 {
+    #[inline(always)]
+    fn K() -> usize {
+        47
+    }
+}
+
+/// Marker trait for generating K=46 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K46;
+
+impl KmerSize for K46 {
+    #[inline(always)]
+    fn K() -> usize {
+        46
+    }
+}
+
+/// Marker trait for generating K=45 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K45;
+
+impl KmerSize for K45 {
+    #[inline(always)]
+    fn K() -> usize {
+        45
+    }
+}
+
+/// Marker trait for generating K=44 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K44;
+
+impl KmerSize for K44 {
+    #[inline(always)]
+    fn K() -> usize {
+        44
+    }
+}
+
+/// Marker trait for generating K=43 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K43;
+
+impl KmerSize for K43 {
+    #[inline(always)]
+    fn K() -> usize {
+        43
+    }
+}
+
+/// Marker trait for generating K=42 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K42;
+
+impl KmerSize for K42 {
+    #[inline(always)]
+    fn K() -> usize {
+        42
+    }
+}
+
+/// Marker trait for generating K=41 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K41;
+
+impl KmerSize for K41 {
+    #[inline(always)]
+    fn K() -> usize {
+        41
+    }
+}
+
 /// Marker trait for generating K=40 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K40;
@@ -707,6 +1005,83 @@ impl KmerSize for K40 {
     #[inline(always)]
     fn K() -> usize {
         40
+    }
+}
+
+/// Marker trait for generating K=39 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K39;
+
+impl KmerSize for K39 {
+    #[inline(always)]
+    fn K() -> usize {
+        39
+    }
+}
+
+/// Marker trait for generating K=38 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K38;
+
+impl KmerSize for K38 {
+    #[inline(always)]
+    fn K() -> usize {
+        38
+    }
+}
+
+/// Marker trait for generating K=37 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K37;
+
+impl KmerSize for K37 {
+    #[inline(always)]
+    fn K() -> usize {
+        37
+    }
+}
+
+/// Marker trait for generating K=36 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K36;
+
+impl KmerSize for K36 {
+    #[inline(always)]
+    fn K() -> usize {
+        36
+    }
+}
+
+/// Marker trait for generating K=35 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K35;
+
+impl KmerSize for K35 {
+    #[inline(always)]
+    fn K() -> usize {
+        35
+    }
+}
+
+/// Marker trait for generating K=34 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K34;
+
+impl KmerSize for K34 {
+    #[inline(always)]
+    fn K() -> usize {
+        34
+    }
+}
+
+/// Marker trait for generating K=33 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K33;
+
+impl KmerSize for K33 {
+    #[inline(always)]
+    fn K() -> usize {
+        33
     }
 }
 
@@ -732,7 +1107,7 @@ impl KmerSize for K30 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=29 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K29;
 
@@ -743,7 +1118,7 @@ impl KmerSize for K29 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=28 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K28;
 
@@ -754,7 +1129,7 @@ impl KmerSize for K28 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=27 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K27;
 
@@ -765,7 +1140,7 @@ impl KmerSize for K27 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=26 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K26;
 
@@ -776,7 +1151,7 @@ impl KmerSize for K26 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=25 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K25;
 
@@ -798,7 +1173,7 @@ impl KmerSize for K24 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=23 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K23;
 
@@ -810,7 +1185,7 @@ impl KmerSize for K23 {
 }
 
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=22 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K22;
 
@@ -821,7 +1196,7 @@ impl KmerSize for K22 {
     }
 }
 
-/// Marker trait for generating K=20 Kmers
+/// Marker trait for generating K=21 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K21;
 
@@ -843,7 +1218,40 @@ impl KmerSize for K20 {
     }
 }
 
-/// Marker trait for generating K=14 Kmers
+/// Marker trait for generating K=19 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K19;
+
+impl KmerSize for K19 {
+    #[inline(always)]
+    fn K() -> usize {
+        19
+    }
+}
+
+/// Marker trait for generating K=18 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K18;
+
+impl KmerSize for K18 {
+    #[inline(always)]
+    fn K() -> usize {
+        18
+    }
+}
+
+/// Marker trait for generating K=17 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K17;
+
+impl KmerSize for K17 {
+    #[inline(always)]
+    fn K() -> usize {
+        17
+    }
+}
+
+/// Marker trait for generating K=15 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K15;
 
@@ -865,6 +1273,17 @@ impl KmerSize for K14 {
     }
 }
 
+/// Marker trait for generating K=13 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K13;
+
+impl KmerSize for K13 {
+    #[inline]
+    fn K() -> usize {
+        13
+    }
+}
+
 /// Marker trait for generating K=12 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K12;
@@ -876,7 +1295,18 @@ impl KmerSize for K12 {
     }
 }
 
-/// Marker trait for generating K=12 Kmers
+/// Marker trait for generating K=11 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K11;
+
+impl KmerSize for K11 {
+    #[inline]
+    fn K() -> usize {
+        11
+    }
+} 
+
+/// Marker trait for generating K=10 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K10;
 
@@ -884,6 +1314,28 @@ impl KmerSize for K10 {
     #[inline]
     fn K() -> usize {
         10
+    }
+}
+
+/// Marker trait for generating K=9 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K9;
+
+impl KmerSize for K9 {
+    #[inline(always)]
+    fn K() -> usize {
+        9
+    }
+}
+
+/// Marker trait for generating K=7 Kmers
+#[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct K7;
+
+impl KmerSize for K7 {
+    #[inline(always)]
+    fn K() -> usize {
+        7
     }
 }
 
@@ -898,7 +1350,7 @@ impl KmerSize for K6 {
     }
 }
 
-/// Marker trait for generating K=6 Kmers
+/// Marker trait for generating K=5 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K5;
 
@@ -908,7 +1360,7 @@ impl KmerSize for K5 {
         5
     }
 }
-/// Marker trait for generating K=6 Kmers
+/// Marker trait for generating K=4 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K4;
 
@@ -918,7 +1370,7 @@ impl KmerSize for K4 {
         4
     }
 }
-/// Marker trait for generating K=6 Kmers
+/// Marker trait for generating K=3 Kmers
 #[derive(Debug, Hash, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct K3;
 
@@ -1182,9 +1634,222 @@ mod tests {
     }
 
     #[test]
+    fn test_kmer_63() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K63>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_62() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K62>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_61() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K61>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_60() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K60>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_59() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K59>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_58() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K58>>();
+        }
+    }
+
+
+    #[test]
+    fn test_kmer_57() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K57>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_56() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K56>>();
+        }
+    }
+
+
+    #[test]
+    fn test_kmer_55() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K55>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_54() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K54>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_53() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K53>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_52() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K52>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_51() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K51>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_50() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K50>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_49() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K49>>();
+        }
+    }
+
+
+    #[test]
     fn test_kmer_48() {
         for _ in 0..10000 {
             check_kmer::<VarIntKmer<u128, K48>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_47() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K47>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_46() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K46>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_45() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K45>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_44() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K44>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_43() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K43>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_42() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K42>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_41() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K41>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_40() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K40>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_39() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K39>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_38() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K38>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_37() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K37>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_36() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K36>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_35() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K35>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_34() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K34>>();
+        }
+    }
+
+    #[test]
+    fn test_kmer_33() {
+        for _ in 0..10000 {
+            check_kmer::<VarIntKmer<u128, K33>>();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,6 +653,11 @@ impl Exts {
         }
     }
 
+    /// subtract an Exts from an Exts
+    pub fn subtract(&self, v: Exts) -> Exts {
+        Exts { val: self.val & !v.val }
+    }
+
     pub fn set(&self, dir: Dir, pos: u8) -> Exts {
         let shift = pos
             + match dir {
@@ -661,6 +666,17 @@ impl Exts {
             };
 
         let new_val = self.val | (1u8 << shift);
+        Exts { val: new_val }
+    }
+
+    pub fn remove(&self, dir: Dir, pos: u8) -> Exts {
+        let shift = pos
+            + match dir {
+                Dir::Right => 4,
+                Dir::Left => 0,
+            };
+
+        let new_val = self.val & !(1u8 << shift);
         Exts { val: new_val }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1291,6 +1291,13 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_ext() {
+        let ext = Exts::new(0b11111011);
+        assert_eq!(ext.remove(Dir::Right, 0).val, 0b11101011);
+        assert_eq!(ext.remove(Dir::Left, 1).val, 0b11111001);
+    }
+
+    #[test]
     fn test_edge_mult() {
         let mut edge_mult = EdgeMult::new();
         assert_eq!(edge_mult.edge_mults, [0; 2*ALPHABET_SIZE]);

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -602,9 +602,9 @@ impl<D: Clone + Copy> Display for ReadsPaired<D> {
     }
 }
 
-/// Trait for ReadData
+/// Trait for ReadData, [`ID`]s can only be generated from [Marbel](https://github.com/jlab/marbel) reads
 pub trait ReadData: PartialEq + Hash + serde::Serialize + DeserializeOwned + Debug + Clone + Copy + Eq + Send + Sync + Ord {
-    /// geneate a read data
+    /// geneate a read data, [`ID`]s and [`IDTag`]s can only be generated from [Marbel](https://github.com/jlab/marbel) reads
     fn read_data(gene_ids: &mut BiMap<String, ID>, read_name: &[u8], tag: Tag) -> Self;
     /// if available, get a tag
     fn get_tag(&self) -> Option<Tag>;

--- a/src/test.rs
+++ b/src/test.rs
@@ -591,7 +591,7 @@ mod tests {
 
         let all_seqs_p = crate::reads::ReadsPaired::Unpaired { reads: all_seqs };
         // Assemble w/ tips
-        let (valid_kmers_errs, _): (BoomHashMap2<K, Exts, TagsCountsSumData>, _) = filter::filter_kmers(
+        let (valid_kmers_errs, _): (BoomHashMap2<K, Exts, TagsCountsEMData>, _) = filter::filter_kmers(
             &all_seqs_p,
             &config,
             stranded,
@@ -635,6 +635,7 @@ mod tests {
         let mut graph = graph.finish();
         graph.fix_exts(None);
         graph.fix_edge_mults();
+        let _ = graph.filter_edges(2);
         graph.print();
         /* graph.to_dot("test_out", &|d| format!("{:?}", d));
         graph.to_dot_parallel("test_out_par", &|d  format!("{:?}", d)); */

--- a/tests/test_colors.rs
+++ b/tests/test_colors.rs
@@ -44,25 +44,25 @@ fn test_colors() {
 
     let node_id = 3;
     let node = graph_tcpem.get_node(node_id);
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 3, len: 16, exts: T|C, seq:\nCCGATACTTCTTCACG\nsamples              - counts\nC_H200               - 1\nC_H300               - 1\nC_H500               - 1\nC_H600               - 1\nsum: 4, p-value: 0.05366346, log2(fold\nchange): inf, edge coverage:\nA: 0 | 0\nC: 0 | 4\nG: 0 | 0\nT: 4 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
+    assert_eq!("[style=filled, color=black, penwidth=10, fillcolor=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 3, len: 16, exts: T|C, seq:\nCCGATACTTCTTCACG\nsamples              - counts\nC_H200               - 1\nC_H300               - 1\nC_H500               - 1\nC_H600               - 1\nsum: 4, p-value: 0.05366346, log2(fold\nchange): inf, edge coverage:\nA: 0 | 0\nC: 0 | 4\nG: 0 | 0\nT: 4 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
     assert_eq!("[color=red, penwidth=9.683096, label=\"C: 4\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
 
     let node_id = 27;
     let node = graph_tcpem.get_node(node_id);
     println!("{:?}", node.data());
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 0.5 1\", fontcolor=black, label=\"id: 27, len: 16, exts: C|G, seq:\nCAGGTCCGTGGCCAGG\nsamples              - counts\nP_T400               - 1\nsum: 1, p-value: 0.3910022, log2(fold\nchange): -inf, edge coverage:\nA: 0 | 0\nC: 1 | 0\nG: 0 | 1\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
+    assert_eq!("[style=filled, color=black, penwidth=10, fillcolor=\"0 0.5 1\", fontcolor=black, label=\"id: 27, len: 16, exts: C|G, seq:\nCAGGTCCGTGGCCAGG\nsamples              - counts\nP_T400               - 1\nsum: 1, p-value: 0.3910022, log2(fold\nchange): -inf, edge coverage:\nA: 0 | 0\nC: 1 | 0\nG: 0 | 1\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
     assert_eq!("[color=red, penwidth=3, label=\"G: 1\"]", node.edge_dot_default(&colors, 2, debruijn::Dir::Right, true));
 
     let node_id = 40;
     let node = graph_tcpem.get_node(node_id);
     println!("{:?}", node.data());
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.15937972 0.5 1\", fontcolor=black, label=\"id: 40, len: 16, exts: A|AG, seq:\nGCTTTGCATCAGAAGA\nsamples              - counts\nC_H100               - 1\nC_H400               - 2\nP_T200               - 1\nP_T300               - 1\nP_T400               - 1\nsum: 6, p-value: 0.86424315, log2(fold\nchange): -0.19431013, edge coverage:\nA: 6 | 3\nC: 0 | 0\nG: 0 | 3\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
+    assert_eq!("[style=filled, color=black, penwidth=10, fillcolor=\"0.15937972 0.5 1\", fontcolor=black, label=\"id: 40, len: 16, exts: A|AG, seq:\nGCTTTGCATCAGAAGA\nsamples              - counts\nC_H100               - 1\nC_H400               - 2\nP_T200               - 1\nP_T300               - 1\nP_T400               - 1\nsum: 6, p-value: 0.86424315, log2(fold\nchange): -0.19431013, edge coverage:\nA: 6 | 3\nC: 0 | 0\nG: 0 | 3\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
     assert_eq!("[color=red, penwidth=8.296228, label=\"A: 3\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Right, true));
     
     let node_id = 2458;
     let node = graph_tcpem.get_node(node_id);
     println!("{:?}", node.data());
-    assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 1 1\", fontcolor=black, label=\"id: 2458, len: 16, exts: C|A, seq:\nTCTCGTACTAAGTTCA\nsamples              - counts\nC_H600               - 1\nP_T100               - 1\nP_T200               - 1\nP_T300               - 1\nP_T400               - 2\nsum: 6, p-value: 0.030437965, log2(fold\nchange): -4.4442472, edge coverage:\nA: 0 | 6\nC: 6 | 0\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
+    assert_eq!("[style=filled, color=black, penwidth=10, fillcolor=\"0 1 1\", fontcolor=black, label=\"id: 2458, len: 16, exts: C|A, seq:\nTCTCGTACTAAGTTCA\nsamples              - counts\nC_H600               - 1\nP_T100               - 1\nP_T200               - 1\nP_T300               - 1\nP_T400               - 2\nsum: 6, p-value: 0.030437965, log2(fold\nchange): -4.4442472, edge coverage:\nA: 0 | 6\nC: 6 | 0\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
     assert_eq!("[color=red, penwidth=11.637776, label=\"A: 6\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Right, true));
 
     // test with color mode SampleGroups

--- a/tests/test_colors.rs
+++ b/tests/test_colors.rs
@@ -40,27 +40,30 @@ fn test_colors() {
     let node_id = 0;
     let node = graph_tcpem.get_node(node_id);
     assert_eq!("[style=filled, color=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 0, len: 16, exts: A|C, seq:\nCCAGCTGTCCCAGATA\nsamples              - counts\nC_H600               - 1\nsum: 1, p-value: 0.37390098, log2(fold\nchange): inf, edge coverage:\nA: 1 | 0\nC: 0 | 1\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, false));
-    assert_eq!("[color=blue, penwidth=1, label=\"A: 1\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Left, true));
+    assert_eq!("[color=blue, penwidth=3, label=\"A: 1\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Left, true));
 
     let node_id = 3;
     let node = graph_tcpem.get_node(node_id);
     assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.33333334 0.5 1\", fontcolor=black, label=\"id: 3, len: 16, exts: T|C, seq:\nCCGATACTTCTTCACG\nsamples              - counts\nC_H200               - 1\nC_H300               - 1\nC_H500               - 1\nC_H600               - 1\nsum: 4, p-value: 0.05366346, log2(fold\nchange): inf, edge coverage:\nA: 0 | 0\nC: 0 | 4\nG: 0 | 0\nT: 4 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
-    assert_eq!("[color=red, penwidth=8.469343, label=\"C: 4\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[color=red, penwidth=9.683096, label=\"C: 4\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
 
     let node_id = 27;
     let node = graph_tcpem.get_node(node_id);
+    println!("{:?}", node.data());
     assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 0.5 1\", fontcolor=black, label=\"id: 27, len: 16, exts: C|G, seq:\nCAGGTCCGTGGCCAGG\nsamples              - counts\nP_T400               - 1\nsum: 1, p-value: 0.3910022, log2(fold\nchange): -inf, edge coverage:\nA: 0 | 0\nC: 1 | 0\nG: 0 | 1\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
-    assert_eq!("[color=red, penwidth=-inf, label=\"C: 0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[color=red, penwidth=3, label=\"G: 1\"]", node.edge_dot_default(&colors, 2, debruijn::Dir::Right, true));
 
     let node_id = 40;
     let node = graph_tcpem.get_node(node_id);
+    println!("{:?}", node.data());
     assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0.15937972 0.5 1\", fontcolor=black, label=\"id: 40, len: 16, exts: A|AG, seq:\nGCTTTGCATCAGAAGA\nsamples              - counts\nC_H100               - 1\nC_H400               - 2\nP_T200               - 1\nP_T300               - 1\nP_T400               - 1\nsum: 6, p-value: 0.86424315, log2(fold\nchange): -0.19431013, edge coverage:\nA: 6 | 3\nC: 0 | 0\nG: 0 | 3\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
-    assert_eq!("[color=red, penwidth=-inf, label=\"C: 0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[color=red, penwidth=8.296228, label=\"A: 3\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Right, true));
     
     let node_id = 2458;
     let node = graph_tcpem.get_node(node_id);
+    println!("{:?}", node.data());
     assert_eq!("[style=filled, color=black, penwidth=7, fillcolor=\"0 1 1\", fontcolor=black, label=\"id: 2458, len: 16, exts: C|A, seq:\nTCTCGTACTAAGTTCA\nsamples              - counts\nC_H600               - 1\nP_T100               - 1\nP_T200               - 1\nP_T300               - 1\nP_T400               - 2\nsum: 6, p-value: 0.030437965, log2(fold\nchange): -4.4442472, edge coverage:\nA: 0 | 6\nC: 6 | 0\nG: 0 | 0\nT: 0 | 0\n\"]", node.node_dot_default(&colors, &config_tcpem, &translator, true));
-    assert_eq!("[color=red, penwidth=-inf, label=\"C: 0\"]", node.edge_dot_default(&colors, 1, debruijn::Dir::Right, true));
+    assert_eq!("[color=red, penwidth=11.637776, label=\"A: 6\"]", node.edge_dot_default(&colors, 0, debruijn::Dir::Right, true));
 
     // test with color mode SampleGroups
 

--- a/tests/test_colors.rs
+++ b/tests/test_colors.rs
@@ -141,9 +141,18 @@ fn test_colors() {
         vec![0, 1, 2, 3]
     );
 
+    graph_tcpem.to_dot_with_path(
+        "test_dot_with_paths.dot", 
+        &|node, base, dir, flipped| node.edge_dot_default(&colors, base, dir, flipped),
+        &colors,
+        &translator,
+        &config_tcpem
+    );
+
     remove_file("test_dot.dot").unwrap();
     remove_file("test_dot_parallel.dot").unwrap();
     remove_file("test_dot_partial.dot").unwrap();
+    remove_file("test_dot_with_paths.dot").unwrap();
 
     // write node to gfa
 

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -271,3 +271,11 @@ fn test_summary_data() {
     )); 
 
 }
+
+/// add the alignment buffer to a structure
+/// - `size_heap`: contents of boxes/vectors -> are stored separately and do not go into alignment calculation
+fn size_aligned(size_stack: usize, size_heap: usize, align: usize) -> usize {
+    let buffer = align - (size_stack % align);
+
+    buffer + size_heap + size_stack
+}


### PR DESCRIPTION
- all k-mer sizes up to 64
- new method  `DebruijnGraph::to_dot_with_paths`: prints to dot while highlighting a path
- new method `DebruijnGraph::iter_edges`: iterates over all edges of the graph
- new method `DebruijnGraph::filter_edges`: removes edges below certain coverage