### PR TITLE
Memory fixes, extended error removal methods, add `EdgeMap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ Cargo.lock
 *.gfa
 *.fasta
 lcov.info
+compressed*
+uncompressed*
+*c_ladders.csv

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ Cargo.lock
 *.gfa
 *.fasta
 lcov.info
-compressed*
-uncompressed*
+*compressed*
 *c_ladders.csv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debruijn"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Elena Volp <elena.volp@uni-giessen.de>"]
 license = "MIT"
 edition = '2021'

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -280,13 +280,12 @@ where
     }
 
     /// Generate complete unbranched edges
-    fn extend_node(&mut self, start_node: usize, start_dir: Dir) -> (Vec<(usize, Dir)>, Exts, Option<SingleDirEdgeMult>, Option<SingleDirEdgeMap>) {
+    fn extend_node(&mut self, start_node: usize, start_dir: Dir) -> (Vec<(usize, Dir)>, TerminalExt) {
         let mut current_dir = start_dir;
         let mut current_node = start_node;
         let mut path = Vec::new();
-        let final_ext: Exts; // must get set below
-        let final_em: Option<SingleDirEdgeMult>; // must get set below
-        let final_emap: Option<SingleDirEdgeMap>; // must get set below
+        // must get set below
+        let terminal: TerminalExt;
 
         self.available_nodes.remove(start_node);
 
@@ -302,24 +301,22 @@ where
                     current_dir = next_dir_outgoing;
                 }
                 ExtModeNode::Terminal(term) => {
-                    final_ext = term.exts;
-                    final_em = term.edge_mults;
-                    final_emap = term.edge_maps;
+                    terminal = term;
 
                     break;
                 }
             }
         }
 
-        (path, final_ext, final_em, final_emap)
+        (path, terminal)
     }
 
     // Determine the sequence and extensions of the maximal unbranched
     // edge, centered around the given edge number
     #[inline(never)]
     fn build_node(&mut self, seed_node: usize) -> (DnaString, Exts, VecDeque<(usize, Dir)>, D) {
-        let (l_path, l_ext, l_em, l_emap) = self.extend_node(seed_node, Dir::Left);
-        let (r_path, r_ext, r_em, r_emap) = self.extend_node(seed_node, Dir::Right);
+        let (l_path, l_terminal) = self.extend_node(seed_node, Dir::Left);
+        let (r_path, r_terminal) = self.extend_node(seed_node, Dir::Right);
 
         // Stick together edge chunks to get full edge sequence
         let mut node_path = VecDeque::new();
@@ -343,22 +340,30 @@ where
                 .reduce(node_data, self.graph.get_node(next_node).data());
         }
 
-        let (left_extend_exts, left_extend_em, left_extend_emap) = match l_path.last() {
-            None => (l_ext, l_em, l_emap),
-            Some(&(_, Dir::Left)) => (l_ext.complement(), l_em.map(|em| em.complement()), l_emap.map(|em| em.complement())),
-            Some(&(_, Dir::Right)) => (l_ext, l_em, l_emap),
+        let left_terminal = match l_path.last() {
+            None => l_terminal,
+            Some(&(_, Dir::Left)) => TerminalExt::new(
+                l_terminal.exts.complement(), 
+                l_terminal.edge_mults.map(|em| em.complement()), 
+                l_terminal.edge_maps.map(|em| em.complement())
+            ),
+            Some(&(_, Dir::Right)) => l_terminal,
         };
 
-        let (right_extend_exts, right_extend_em, right_extend_emap) = match r_path.last() {
-            None => (r_ext, r_em, r_emap),
-            Some(&(_, Dir::Left)) => (r_ext, r_em, r_emap),
-            Some(&(_, Dir::Right)) => (r_ext.complement(), r_em.map(|em| em.complement()), r_emap.map(|em| em.complement()))
+        let right_terminal = match r_path.last() {
+            None => r_terminal,
+            Some(&(_, Dir::Left)) => r_terminal,
+            Some(&(_, Dir::Right)) => TerminalExt::new(
+                r_terminal.exts.complement(), 
+                r_terminal.edge_mults.map(|em| em.complement()), 
+                r_terminal.edge_maps.map(|em| em.complement())
+            )
         };
 
         let path_seq = self.graph.sequence_of_path(node_path.iter());
 
-        let new_em = EdgeMult::from_single_dirs(&left_extend_em, &right_extend_em);
-        let new_emap = EdgeMap::from_single_dirs(&left_extend_emap, &right_extend_emap);
+        let new_em = EdgeMult::from_single_dirs(&left_terminal.edge_mults, &right_terminal.edge_mults);
+        let new_emap = EdgeMap::from_single_dirs(&left_terminal.edge_maps, &right_terminal.edge_maps);
 
         node_data.set_edge_mults(new_em);
         node_data.set_mapped_edge_ids(new_emap);
@@ -366,7 +371,7 @@ where
         // return sequence and extensions
         (
             path_seq,
-            Exts::from_single_dirs(left_extend_exts, right_extend_exts),
+            Exts::from_single_dirs(left_terminal.exts, right_terminal.exts),
             node_path,
             node_data,
         )
@@ -551,15 +556,13 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
     /// Also return the extensions at the end of this line.
     /// Sub-lines break if their extensions are not available in this shard
     #[inline(never)]
-    fn extend_kmer(&mut self, kmer: K, start_dir: Dir, path: &mut Vec<(K, Dir)>) -> (Exts, Option<SingleDirEdgeMult>, Option<SingleDirEdgeMap>) {
+    fn extend_kmer(&mut self, kmer: K, start_dir: Dir, path: &mut Vec<(K, Dir)>) -> TerminalExt {
         let mut current_dir = start_dir;
         let mut current_kmer = kmer;
         path.clear();
 
         // must get set below
-        let final_exts: Exts;
-        let final_em: Option<SingleDirEdgeMult>; 
-        let final_emap: Option<SingleDirEdgeMap>; 
+        let terminal: TerminalExt;
 
         // get id of kmer and remove from available kmers
         let id = self.get_kmer_id(&kmer).expect("should have this kmer");
@@ -577,15 +580,13 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
                     current_dir = next_dir;
                 }
                 ExtMode::Terminal(term) => {
-                    final_exts = term.exts;
-                    final_em = term.edge_mults;
-                    final_emap = term.edge_maps;                    
+                    terminal = term;                   
                     break;
                 }
             }
         }
 
-        (final_exts, final_em, final_emap)
+        terminal
     }
 
     /// Build the edge surrounding a kmer
@@ -605,7 +606,7 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
         let mut node_data = self.get_kmer_data(&seed).1.clone();
 
         // Unique path from seed kmer with Dir Left is built
-        let l_ext = self.extend_kmer(seed, Dir::Left, path);
+        let l_term = self.extend_kmer(seed, Dir::Left, path);
 
 
         // Add on the left path
@@ -622,15 +623,19 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             node_data = self.spec.reduce(node_data, kmer_data)
         }
 
-        let (left_extend_exts, left_extend_em, left_extend_emap)  = match path.last() {
-            None => l_ext,
-            Some(&(_, Dir::Left)) => l_ext,
-            Some(&(_, Dir::Right)) => (l_ext.0.complement(), l_ext.1.map(|em| em.complement()), l_ext.2.map(|em| em.complement()))
+        let left_terminal  = match path.last() {
+            None => l_term,
+            Some(&(_, Dir::Left)) => l_term,
+            Some(&(_, Dir::Right)) => TerminalExt::new(
+                l_term.exts.complement(), 
+                l_term.edge_mults.map(|em| em.complement()), 
+                l_term.edge_maps.map(|em| em.complement())
+            )
         };
 
 
         // Unique path from seed kmer with Dir Right is built
-        let r_ext = self.extend_kmer(seed, Dir::Right, path);
+        let r_term = self.extend_kmer(seed, Dir::Right, path);
 
         // Add on the right path
         for &(next_kmer, dir) in path.iter() {
@@ -645,18 +650,22 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             node_data = self.spec.reduce(node_data, kmer_data)
         }
 
-        let (right_extend_exts, right_extend_em, right_extend_emap) = match path.last() {
-            None => r_ext,
-            Some(&(_, Dir::Left)) => (r_ext.0.complement(), r_ext.1.map(|em| em.complement()), r_ext.2.map(|em| em.complement())),
-            Some(&(_, Dir::Right)) => r_ext,
+        let right_terminal = match path.last() {
+            None => r_term,
+            Some(&(_, Dir::Left)) => TerminalExt::new(
+                r_term.exts.complement(), 
+                r_term.edge_mults.map(|em| em.complement()), 
+                r_term.edge_maps.map(|em| em.complement())
+            ),
+            Some(&(_, Dir::Right)) => r_term,
         };
 
-        let new_em = EdgeMult::from_single_dirs(&left_extend_em, &right_extend_em);
-        let new_emap = EdgeMap::from_single_dirs(&left_extend_emap, &right_extend_emap);
+        let new_em = EdgeMult::from_single_dirs(&left_terminal.edge_mults, &right_terminal.edge_mults);
+        let new_emap = EdgeMap::from_single_dirs(&left_terminal.edge_maps, &right_terminal.edge_maps);
         node_data.set_edge_mults(new_em);
         node_data.set_mapped_edge_ids(new_emap);
         
-        (Exts::from_single_dirs(left_extend_exts, right_extend_exts), node_data)
+        (Exts::from_single_dirs(left_terminal.exts, right_terminal.exts), node_data)
     }
 
     /// Compress a set of kmers and their extensions and metadata into a base DeBruijn graph.

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -6,7 +6,6 @@ use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
 use log::debug;
 use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::mem;
 use std::time::Instant;
@@ -617,7 +616,7 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
     pub fn compress_kmers(
         stranded: bool,
         spec: &S,
-        index: &BoomHashMap2<K, Exts, D>,
+        index: BoomHashMap2<K, Exts, D>,
         progress: bool,
     ) -> BaseGraph<K, D> {
         
@@ -636,7 +635,7 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             d: PhantomData,
             di: PhantomData,
             available_kmers,
-            index,
+            index: &index,
         };
 
         // Path-compressed De Bruijn graph will be created here
@@ -679,6 +678,8 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             }
         }
 
+        graph.shrink_to_fit();
+
         if progress { println!() };
 
         graph
@@ -691,7 +692,7 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
 pub fn compress_kmers_with_hash<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: CompressionSpec<D> + Send + Sync>(
     stranded: bool,
     spec: &S,
-    index: &BoomHashMap2<K, Exts, D>,
+    index: BoomHashMap2<K, Exts, D>,
     time: bool,
     progress: bool,
 ) -> BaseGraph<K, D> {
@@ -719,7 +720,7 @@ pub fn compress_kmers<K: Kmer, D: Clone + Debug  + Send + Sync + SummaryData<DI>
     }
 
     let index = BoomHashMap2::new(keys, exts, data);
-    CompressFromHash::<K, D, DI, S>::compress_kmers(stranded, spec, &index, false)
+    CompressFromHash::<K, D, DI, S>::compress_kmers(stranded, spec, index, false)
 }
 
 /// Build graph from a set of kmers with unknown extensions by finding the extensions on the fly.
@@ -763,12 +764,12 @@ pub fn compress_kmers_no_exts<K: Kmer + Send + Sync, D: Clone + Debug + Send + S
     assert_eq!(kmer_set.len(), keys.len());
 
     let index = BoomHashMap2::new(keys, exts, data);
-    CompressFromHash::<K, D, DI, S>::compress_kmers(stranded, spec, &index,false)
+    CompressFromHash::<K, D, DI, S>::compress_kmers(stranded, spec, index,false)
 }
 
 /// build an uncompressed graph from hashed k-mers
 pub fn uncompressed_graph<K: Kmer, D: Clone + Debug>(
-    index: &BoomHashMap2<K, Exts, D>,
+    index: BoomHashMap2<K, Exts, D>,
     stranded: bool
 ) -> BaseGraph<K, D> {
 
@@ -782,6 +783,9 @@ pub fn uncompressed_graph<K: Kmer, D: Clone + Debug>(
         }
         graph.add(&kmer_seq, *exts, data.clone());
     }
+
+    graph.shrink_to_fit();
+
     graph
 }
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -13,22 +13,35 @@ use std::time::Instant;
 use crate::dna_string::DnaString;
 use crate::graph::{BaseGraph, DebruijnGraph};
 use crate::summarizer::SummaryData;
-use crate::{Dir, EdgeMult, SingleDirEdgeMult, PROGRESS_STYLE};
+use crate::{Dir, EdgeMap, EdgeMult, PROGRESS_STYLE, SingleDirEdgeMap, SingleDirEdgeMult};
 use crate::Exts;
 use crate::Kmer;
 use crate::Vmer;
 use boomphf::hashmap::BoomHashMap2;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 enum ExtMode<K: Kmer> {
     Unique(K, Dir, Exts),
-    Terminal(Exts, Option<SingleDirEdgeMult>),
+    Terminal(TerminalExt),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 enum ExtModeNode {
     Unique(usize, Dir, Exts),
-    Terminal(Exts, Option<SingleDirEdgeMult>),
+    Terminal(TerminalExt),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct TerminalExt {
+    exts: Exts,
+    edge_mults: Option<SingleDirEdgeMult>,
+    edge_maps: Option<SingleDirEdgeMap>
+}
+
+impl TerminalExt {
+    fn new(exts: Exts, edge_mults: Option<SingleDirEdgeMult>, edge_maps: Option<SingleDirEdgeMap>) -> Self {
+        TerminalExt { exts, edge_mults, edge_maps }
+    }
 }
 
 /// Customize the path-compression process. Implementing this trait lets the user
@@ -170,7 +183,11 @@ where
         if exts.num_ext_dir(dir) != 1
             || (!self.stranded && node.len() == K::k() && bases.get_kmer::<K>(0).is_palindrome())
         {
-            ExtModeNode::Terminal(exts.single_dir(dir), data.edge_mults().map(|em| em.single_dir(dir)))
+            ExtModeNode::Terminal( TerminalExt::new(
+                exts.single_dir(dir), 
+                data.edge_mults().map(|em| em.single_dir(dir)), 
+                data.mapped_edge_ids().map(|em| em.single_dir(dir))
+            ))
         } else {
             // Get the next kmer
             let ext_base = exts.get_unique_extension(dir).expect("should be unique");
@@ -228,7 +245,11 @@ where
                 // or we've already used it,
                 // or it's palindrom and we are not stranded
                 // or the colors were not same
-                return ExtModeNode::Terminal(exts.single_dir(dir), data.edge_mults().map(|em| em.single_dir(dir)));
+                return ExtModeNode::Terminal( TerminalExt::new(
+                    exts.single_dir(dir), 
+                    data.edge_mults().map(|em| em.single_dir(dir)), 
+                    data.mapped_edge_ids().map(|em| em.single_dir(dir))
+                ));
             }
 
             // orientation of next edge
@@ -249,18 +270,23 @@ where
             } else {
                 // there's more than one path
                 // into the target kmer - don't include it
-                ExtModeNode::Terminal(exts.single_dir(dir),data.edge_mults().map(|em| em.single_dir(dir)))
+                ExtModeNode::Terminal( TerminalExt::new(
+                exts.single_dir(dir), 
+                data.edge_mults().map(|em| em.single_dir(dir)), 
+                data.mapped_edge_ids().map(|em| em.single_dir(dir))
+            ))
             }
         }
     }
 
     /// Generate complete unbranched edges
-    fn extend_node(&mut self, start_node: usize, start_dir: Dir) -> (Vec<(usize, Dir)>, Exts, Option<SingleDirEdgeMult>) {
+    fn extend_node(&mut self, start_node: usize, start_dir: Dir) -> (Vec<(usize, Dir)>, Exts, Option<SingleDirEdgeMult>, Option<SingleDirEdgeMap>) {
         let mut current_dir = start_dir;
         let mut current_node = start_node;
         let mut path = Vec::new();
-        let final_exts: Exts; // must get set below
+        let final_ext: Exts; // must get set below
         let final_em: Option<SingleDirEdgeMult>; // must get set below
+        let final_emap: Option<SingleDirEdgeMap>; // must get set below
 
         self.available_nodes.remove(start_node);
 
@@ -275,23 +301,25 @@ where
                     current_node = next_node;
                     current_dir = next_dir_outgoing;
                 }
-                ExtModeNode::Terminal(ext, em) => {
-                    final_exts = ext;
-                    final_em = em;
+                ExtModeNode::Terminal(term) => {
+                    final_ext = term.exts;
+                    final_em = term.edge_mults;
+                    final_emap = term.edge_maps;
+
                     break;
                 }
             }
         }
 
-        (path, final_exts, final_em)
+        (path, final_ext, final_em, final_emap)
     }
 
     // Determine the sequence and extensions of the maximal unbranched
     // edge, centered around the given edge number
     #[inline(never)]
     fn build_node(&mut self, seed_node: usize) -> (DnaString, Exts, VecDeque<(usize, Dir)>, D) {
-        let (l_path, l_ext, l_em) = self.extend_node(seed_node, Dir::Left);
-        let (r_path, r_ext, r_em) = self.extend_node(seed_node, Dir::Right);
+        let (l_path, l_ext, l_em, l_emap) = self.extend_node(seed_node, Dir::Left);
+        let (r_path, r_ext, r_em, r_emap) = self.extend_node(seed_node, Dir::Right);
 
         // Stick together edge chunks to get full edge sequence
         let mut node_path = VecDeque::new();
@@ -315,22 +343,25 @@ where
                 .reduce(node_data, self.graph.get_node(next_node).data());
         }
 
-        let (left_extend_exts, left_extend_em) = match l_path.last() {
-            None => (l_ext, l_em),
-            Some(&(_, Dir::Left)) => (l_ext.complement(), l_em.map(|em| em.complement())),
-            Some(&(_, Dir::Right)) => (l_ext, l_em),
+        let (left_extend_exts, left_extend_em, left_extend_emap) = match l_path.last() {
+            None => (l_ext, l_em, l_emap),
+            Some(&(_, Dir::Left)) => (l_ext.complement(), l_em.map(|em| em.complement()), l_emap.map(|em| em.complement())),
+            Some(&(_, Dir::Right)) => (l_ext, l_em, l_emap),
         };
 
-        let (right_extend_exts, right_extend_em) = match r_path.last() {
-            None => (r_ext, r_em),
-            Some(&(_, Dir::Left)) => (r_ext, r_em),
-            Some(&(_, Dir::Right)) => (r_ext.complement(), r_em.map(|em| em.complement()))
+        let (right_extend_exts, right_extend_em, right_extend_emap) = match r_path.last() {
+            None => (r_ext, r_em, r_emap),
+            Some(&(_, Dir::Left)) => (r_ext, r_em, r_emap),
+            Some(&(_, Dir::Right)) => (r_ext.complement(), r_em.map(|em| em.complement()), r_emap.map(|em| em.complement()))
         };
 
         let path_seq = self.graph.sequence_of_path(node_path.iter());
 
         let new_em = EdgeMult::from_single_dirs(&left_extend_em, &right_extend_em);
+        let new_emap = EdgeMap::from_single_dirs(&left_extend_emap, &right_extend_emap);
+
         node_data.set_edge_mults(new_em);
+        node_data.set_mapped_edge_ids(new_emap);
 
         // return sequence and extensions
         (
@@ -444,7 +475,11 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
         // kmer is marked terminal if it has not one extension in one direction (if clear path always 1) 
         // or if the graph is not stranded and the kmer is a palindrome
         if exts.num_ext_dir(dir) != 1 || (!self.stranded && kmer.is_palindrome()) {
-            ExtMode::Terminal(exts.single_dir(dir), kmer_data.edge_mults().map(|em| em.single_dir(dir)))
+            ExtMode::Terminal( TerminalExt::new(
+                exts.single_dir(dir), 
+                kmer_data.edge_mults().map(|em| em.single_dir(dir)),
+                kmer_data.mapped_edge_ids().map(|em| em.single_dir(dir))
+            ))
         } else {
             // Get the next kmer
             let ext_base = exts.get_unique_extension(dir).expect("should be unique");
@@ -472,7 +507,11 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
                 Some(id) if self.available_kmers.contains(id) => (),
 
                 // This kmer isn't in this partition, or we've already used it
-                _ => return ExtMode::Terminal(exts.single_dir(dir), kmer_data.edge_mults().map(|em| em.single_dir(dir))),
+                _ => return ExtMode::Terminal( TerminalExt::new(
+                    exts.single_dir(dir), 
+                    kmer_data.edge_mults().map(|em| em.single_dir(dir)),
+                    kmer_data.mapped_edge_ids().map(|em| em.single_dir(dir))
+                )),
             }
 
             // Check condition b)
@@ -499,7 +538,11 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             } else {
                 // there's more than one path
                 // into the target kmer - don't include it
-                ExtMode::Terminal(exts.single_dir(dir), kmer_data.edge_mults().map(|em| em.single_dir(dir)))
+                ExtMode::Terminal( TerminalExt::new(
+                    exts.single_dir(dir), 
+                    kmer_data.edge_mults().map(|em| em.single_dir(dir)),
+                    kmer_data.mapped_edge_ids().map(|em| em.single_dir(dir))
+                ))
             }
         }
     }
@@ -508,13 +551,15 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
     /// Also return the extensions at the end of this line.
     /// Sub-lines break if their extensions are not available in this shard
     #[inline(never)]
-    fn extend_kmer(&mut self, kmer: K, start_dir: Dir, path: &mut Vec<(K, Dir)>) -> (Exts, Option<SingleDirEdgeMult>) {
+    fn extend_kmer(&mut self, kmer: K, start_dir: Dir, path: &mut Vec<(K, Dir)>) -> (Exts, Option<SingleDirEdgeMult>, Option<SingleDirEdgeMap>) {
         let mut current_dir = start_dir;
         let mut current_kmer = kmer;
         path.clear();
 
-        let final_exts: Exts; // must get set below
-        let final_em: Option<SingleDirEdgeMult>; // must get set below
+        // must get set below
+        let final_exts: Exts;
+        let final_em: Option<SingleDirEdgeMult>; 
+        let final_emap: Option<SingleDirEdgeMap>; 
 
         // get id of kmer and remove from available kmers
         let id = self.get_kmer_id(&kmer).expect("should have this kmer");
@@ -531,15 +576,16 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
                     current_kmer = next_kmer;
                     current_dir = next_dir;
                 }
-                ExtMode::Terminal(ext, em) => {
-                    final_exts = ext;
-                    final_em = em;
+                ExtMode::Terminal(term) => {
+                    final_exts = term.exts;
+                    final_em = term.edge_mults;
+                    final_emap = term.edge_maps;                    
                     break;
                 }
             }
         }
 
-        (final_exts, final_em)
+        (final_exts, final_em, final_emap)
     }
 
     /// Build the edge surrounding a kmer
@@ -576,10 +622,10 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             node_data = self.spec.reduce(node_data, kmer_data)
         }
 
-        let (left_extend_exts, left_extend_em)  = match path.last() {
+        let (left_extend_exts, left_extend_em, left_extend_emap)  = match path.last() {
             None => l_ext,
             Some(&(_, Dir::Left)) => l_ext,
-            Some(&(_, Dir::Right)) => (l_ext.0.complement(), l_ext.1.map(|em| em.complement()))
+            Some(&(_, Dir::Right)) => (l_ext.0.complement(), l_ext.1.map(|em| em.complement()), l_ext.2.map(|em| em.complement()))
         };
 
 
@@ -599,14 +645,16 @@ impl<K: Kmer, D: Clone + Debug + Send + Sync + SummaryData<DI>, DI, S: Compressi
             node_data = self.spec.reduce(node_data, kmer_data)
         }
 
-        let (right_extend_exts, right_extend_em) = match path.last() {
+        let (right_extend_exts, right_extend_em, right_extend_emap) = match path.last() {
             None => r_ext,
-            Some(&(_, Dir::Left)) => (r_ext.0.complement(), r_ext.1.map(|em| em.complement())),
+            Some(&(_, Dir::Left)) => (r_ext.0.complement(), r_ext.1.map(|em| em.complement()), r_ext.2.map(|em| em.complement())),
             Some(&(_, Dir::Right)) => r_ext,
         };
 
         let new_em = EdgeMult::from_single_dirs(&left_extend_em, &right_extend_em);
+        let new_emap = EdgeMap::from_single_dirs(&left_extend_emap, &right_extend_emap);
         node_data.set_edge_mults(new_em);
+        node_data.set_mapped_edge_ids(new_emap);
         
         (Exts::from_single_dirs(left_extend_exts, right_extend_exts), node_data)
     }

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -499,6 +499,11 @@ impl DnaString {
     //    }
     //    values[values.len() - 1] =
     // }
+
+    /// shrink the storage of the `DnaString` to fit its contents
+    pub fn shrink_to_fit(&mut self) {
+        self.storage.shrink_to_fit();
+    }
 }
 
 impl fmt::Display for DnaString {
@@ -857,6 +862,13 @@ impl PackedDnaStringSet {
         }
         self.length.push(length as u32);
         //debug!("add to sequence for loop {:?} iterations (pr seq len)", length);
+    }
+
+    /// shrink the storage of the `PackedDnaStringSet` to fit its contents
+    pub fn shrink_to_fit(&mut self) {
+        self.sequence.shrink_to_fit();
+        self.start.shrink_to_fit();
+        self.length.shrink_to_fit();
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -715,7 +715,9 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         seq
     }
 
-    /// map sequences from a fasta file to a **completely uncompressed** and **stranded** debruijn graph
+    /// map sequences from a fasta reference to the nodes of a **completely uncompressed** debruijn graph
+    /// 
+    /// the IDs are stored with the node if the k-mer occured in the reference
     pub fn map_transcripts<P>(&self, path: P, translator: &mut Translator) -> Result<Vec<Box<[ID]>>, String> 
     where 
         P: AsRef<Path>
@@ -774,7 +776,9 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         Ok(boxed_transcripts)
     }
 
-    /// map sequences from a fasta file to a **completely uncompressed** and **stranded** debruijn graph
+    /// map sequences from a fasta reference to the edges of a **completely uncompressed** debruijn graph
+    /// 
+    /// the IDs are stored with the edges if the two k-mers occured together in the reference
     pub fn map_transcripts_to_edges<P>(&self, path: P, translator: &mut Translator) -> Result<Vec<EdgeMap>, String> 
     where 
         P: AsRef<Path>
@@ -1825,7 +1829,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         Ok(())
     }
 
-    /// remove bubbles/ladders and tips in which one path has a quality lower than the given `min_quality`
+    /// remove bubbles/ladders and tips in which one path has a quality lower than the given `min_quality`. 
+    /// The method continues searching on a path for a maximum of (`max_path_fac`` * k - 1).
     pub fn remove_lq_paths<DI>(&mut self, min_quality: BaseQuality, max_path_fac: usize) -> Result<(), String>
     where
         SD: SummaryData<DI>
@@ -1930,7 +1935,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     // check if we have met end criterium -> save path
                     let quality_req =  current_node.data().quality().unwrap() >= min_quality;
                     let len_req = path_length >= min_path;
-                    // path is a simple tip -> save as tip
+                    // path is a simple tip -> save as tip (does not have to meet length requirement)
                     let is_tip = out_edges.is_empty() & (path_groups.len() == 1); // TODO maybe remove req 2 in future
 
                     if quality_req & len_req {
@@ -2055,7 +2060,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         Ok(())
     }
 
-    /// remove bubbles/ladders and tips in which one path has a coverage lower than the other
+    /// remove bubbles/ladders and tips in which one path has a lower coverage than the alternative path. 
+    /// The method continues searching on a path for a maximum of (`max_path_fac`` * k - 1).
+    /// The path is only removed if the average coverage of the lower path is below `max_avg_low_cov` and the 
+    /// average coverage is at least `min_diff_factor` times higher.
     pub fn remove_lc_paths<DI>(&mut self, max_path_fac: usize, min_diff_factor: u32, max_avg_low_cov: f32) -> Result<(), String>
     where
         SD: SummaryData<DI>

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -821,7 +821,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
                     if let Some(node) = self.search_kmer(kmer, Dir::Right) {
                         node_edge_transcript_ids[node].add_id(exts, gene_id);
                     } else if let Some(node) = self.search_kmer(kmer.rc(), Dir::Right) {
-                        node_edge_transcript_ids[node].add_id(exts, gene_id);
+                        node_edge_transcript_ids[node].add_id(exts.rc(), gene_id);
                     }
                 }
                 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -39,6 +39,7 @@ type SmallVec4<T> = SmallVec<[T; 4]>;
 type SmallVec8<T> = SmallVec<[T; 8]>;
 
 use crate::BaseQuality;
+use crate::EdgeMap;
 use crate::bits_to_base;
 use crate::colors::ColorMode;
 use crate::colors::Colors;
@@ -771,6 +772,67 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
         let boxed_transcripts = node_transcript_ids.into_iter().map(|vec| vec.into()).collect();
 
         Ok(boxed_transcripts)
+    }
+
+    /// map sequences from a fasta file to a **completely uncompressed** and **stranded** debruijn graph
+    pub fn map_transcripts_to_edges<P>(&self, path: P, translator: &mut Translator) -> Result<Vec<EdgeMap>, String> 
+    where 
+        P: AsRef<Path>
+    {
+        let reader = fasta::Reader::new(BufReader::new(File::open(path).unwrap()));
+        let mut node_edge_transcript_ids = vec![EdgeMap::default(); self.len()];
+
+        // if the translator has a id translator, use it, else make a new one to use and put it into the translator
+        let id_tr = if let Some(id_tr) = translator.mut_id_translator() {
+            id_tr
+        } else {
+            let new_id_tr = BiHashMap::new();
+            translator.mut_id_translator().replace(new_id_tr);
+            
+            let Some(id_tr) = translator.mut_id_translator() else { panic!("should not happen") };
+
+            id_tr
+        };
+
+        // go through each transcript and map to graph
+        for result in reader.records() {
+            let record = result.expect("error parsing transcripts fasta");
+
+            // get gene id or make new id
+            let gene_id = match id_tr.get_by_left(&record.id().to_string()) {
+                Some(id) => *id,
+                None => {
+                    let new_id = id_tr.len() as ID;
+                    id_tr.insert(record.id().to_string(), new_id);
+                    new_id
+                }
+            };
+
+            // iterate over k-mers in transcript and find each one in the graph
+            let sequence = DnaString::from_acgt_bytes(record.seq());
+
+            for (kmer, exts) in sequence.iter_kmer_exts::<K>(Exts::empty()) {
+                if self.base.stranded {
+                    if let Some(node) = self.search_kmer(kmer, Dir::Right) {
+                        node_edge_transcript_ids[node].add_id(exts, gene_id);
+                    }
+                } else {
+                    // graph is not stranded, look for both the k-mer ansd its reverse complement
+                    if let Some(node) = self.search_kmer(kmer, Dir::Right) {
+                        node_edge_transcript_ids[node].add_id(exts, gene_id);
+                    } else if let Some(node) = self.search_kmer(kmer.rc(), Dir::Right) {
+                        node_edge_transcript_ids[node].add_id(exts, gene_id);
+                    }
+                }
+                
+            }
+        }
+
+        // remove unncecessary memory from boxed slices
+        node_edge_transcript_ids.iter_mut().for_each(|emap| emap.shrink_to_fit());
+        node_edge_transcript_ids.shrink_to_fit();
+
+        Ok(node_edge_transcript_ids)
     }
 
     /// write a node to a dot file
@@ -3087,7 +3149,7 @@ impl<K: Kmer, D: Debug> Iterator for EdgeIter<'_, K, D> {
 mod test {
     use std::fs::remove_file;
 
-    use crate::{BaseQuality, Exts, build_test_graph, colors::Colors, compression::{CheckCompress, ScmapCompress, compress_kmers_with_hash, uncompressed_graph}, dna_string::DnaString, filter::filter_kmers, kmer::{Kmer6, Kmer16, Kmer22}, reads::{Reads, ReadsPaired, Strandedness}, serde::SerKmers, summarizer::{IDMapEMData, IDMapEMQualityData, IDTag, SampleInfo, SummaryConfig, TagsCountsData, TagsCountsSumData, Translator}, test::random_dna};
+    use crate::{BaseQuality, Exts, build_test_graph, colors::Colors, compression::{CheckCompress, ScmapCompress, compress_kmers_with_hash, uncompressed_graph}, dna_string::DnaString, filter::filter_kmers, kmer::{Kmer6, Kmer16, Kmer22}, reads::{Reads, ReadsPaired, Strandedness}, summarizer::{IDMapEMData, IDMapEMQualityData, IDTag, SampleInfo, SummaryConfig, TagsCountsData, TagsCountsSumData, Translator}, test::random_dna};
 
     use crate::{summarizer::SummaryData, Dir};
 
@@ -3168,6 +3230,33 @@ mod test {
         let t_map = unc_graph.map_transcripts(t_ref_path, &mut translator).unwrap();
         assert_eq!(t_map.len(), unc_graph.len());
         assert_eq!(t_map.iter().filter(|&ids| !ids.is_empty()).collect::<Vec<_>>().len(), 439);
+
+        // repeat the same without a previous existing translator
+        let mut new_translator = Translator::empty();
+        let t_map = unc_graph.map_transcripts(t_ref_path, &mut new_translator).unwrap();
+        assert_eq!(t_map.len(), unc_graph.len());
+        assert_eq!(t_map.iter().filter(|&ids| !ids.is_empty()).collect::<Vec<_>>().len(), 439);
+        let mut new_id_strings = new_translator.id_translator().clone().unwrap().into_iter().map(|(name, _id)| name).collect::<Vec<_>>();
+        new_id_strings.sort();
+
+        assert_eq!(id_strings, new_id_strings);
+    }
+
+
+    #[test]
+    fn test_map_transcripts_to_edges() {
+        let t_ref_path = "test_data/test_transcriptome_reference.fasta";
+        let (_, ser_kmers, _) = build_test_graph::<Kmer22, u32, _>();
+        let (kmers, mut translator, _) = ser_kmers.dissolve();
+
+        let unc_graph = uncompressed_graph(kmers, true).finish();
+
+        let mut id_strings = translator.id_translator().clone().unwrap().into_iter().map(|(name, _id)| name).collect::<Vec<_>>();
+        id_strings.sort();
+
+        let t_map = unc_graph.map_transcripts_to_edges(t_ref_path, &mut translator).unwrap();
+        assert_eq!(t_map.len(), unc_graph.len());
+        assert_eq!(t_map.iter().filter(|&emap| !emap.is_empty()).collect::<Vec<_>>().len(), 439);
 
         // repeat the same without a previous existing translator
         let mut new_translator = Translator::empty();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2113,11 +2113,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                 let mut cov_sum = start_out_cov;
                 let mut cov_count = 1;
 
-                println!("start node: {node_id}, out base: {start_out_base}, out cov: {start_out_cov}");
-
                 loop {
                     let current_node = self.get_node(current_node_id);
-                    println!("node: {current_node_id} - {:?}", current_node);
                     let out_edges = current_node.edges(current_in_dir.flip());
 
                     // add current node length to path
@@ -2156,14 +2153,11 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         }
                     }
 
-                    println!("next node: {:?}, next in dir: {:?}, closest_out_cov: {:?}", next_node_id, next_in_dir, closest_out_cov);
-
                     // check if coverage increases on high path, similar to c_increase check but with highest outgoing coverage and start cov
                     // TODO check if better with min_diff_factor
                     // TODO check if we should replace consts with min diff factor
                     let highest_cov = out_edge_coverages.edge_mults.iter().max().unwrap_or(&0);
                     let coverage_req =  (*highest_cov as f32 > out_max_cov as f32 - out_max_cov as f32 * COV_STATE_FACTOR + COV_STATE_ADD) & !c_state_high; // higer coverage than last edge
-                    println!("highest out cov: {highest_cov}, coverage_req: {coverage_req}");
 
                     // check if we have met end criterium -> save path
                     let len_req = path_length >= min_path; // path long enough
@@ -2180,7 +2174,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // check if we have a next node: 
                     let (Some(closest_out_cov), Some(next_node_id), Some(next_in_dir)) = (closest_out_cov, next_node_id, next_in_dir) else { 
-                        println!("interrupting bc no more nodes");
                         break; 
                     };
 
@@ -2192,8 +2185,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         c_state_high = true
                     }
 
-                    println!("state: {:?}", state);
-
                     if c_increase | mult_increase {
                         match state {
                             LadderState::Singular => {
@@ -2202,8 +2193,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                             LadderState::Double => () // ignore
                         };
                     }
-
-                    println!("state: {:?}", state);
 
                     // check if we decrease ladder state
                     // do not check if coverage was already high bc state could be increased for just one node by inc edge
@@ -2223,8 +2212,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                             }
                         }
                     }
-
-                    println!("state: {:?}", state);
 
                     // we have not met the conditions and keep moving
                     current_node_id = next_node_id;
@@ -2291,9 +2278,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
 
             let avg_cov_high_path = (cov_sum as f32 / cov_count as f32) as u32;
-
-            println!("paths: {:?}", possible_paths);
-            println!("tips: {:?}", tips);
 
             // check if we have found end nodes of possible paths by following high coverage paths
             // if so, remove path
@@ -3627,13 +3611,23 @@ mod test {
     }
 
     #[test]
-    fn test_remove_lq_splits() {
+    fn test_remove_lq_splits_s() {
+        test_remove_lq_splits(true);
+    }
+
+    #[test]
+    fn test_remove_lq_splits_us() {
+        test_remove_lq_splits(false);
+    }
+
+    fn test_remove_lq_splits(stranded: bool) {
         let print = false;
-        let stranded = false;
+        let strandedness = if stranded { Strandedness::Forward } else { Strandedness::Unstranded };
+
 
         type K = Kmer16;
 
-        let seqs = build_reads_quality_test(Strandedness::Unstranded);
+        let seqs = build_reads_quality_test(strandedness);
         let sample_info = SampleInfo::new(1, 0b111110, vec![1000, 10, 20, 20, 20, 20]);
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<IDMapEMQualityData, K, IDTag>(&seqs, &summary_config, false, 1., false);
@@ -3694,13 +3688,22 @@ mod test {
     }
 
     #[test]
-    fn test_remove_lq_paths() {
+    fn test_remove_lq_paths_s() {
+        test_remove_lq_paths(true);
+    }
+
+    #[test]
+    fn test_remove_lq_paths_us() {
+        test_remove_lq_paths(false);
+    }
+
+    fn test_remove_lq_paths(stranded: bool) {
         let print = false;
-        let stranded = false;
+        let strandedness = if stranded { Strandedness::Forward } else { Strandedness::Unstranded };
 
         type K = Kmer16;
 
-        let seqs = build_reads_quality_test(Strandedness::Unstranded);
+        let seqs = build_reads_quality_test(strandedness);
         let sample_info = SampleInfo::new(1, 0b111110, vec![1000, 10, 20, 20, 20, 20]);
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<IDMapEMQualityData, K, IDTag>(&seqs, &summary_config, false, 1., false);
@@ -3761,10 +3764,20 @@ mod test {
     }
 
     #[test]
-    fn test_remove_lc_paths() {
+    fn test_remove_lc_paths_s() {
+        test_remove_lc_paths(true);
+    }
+
+    #[test]
+    fn test_remove_lc_paths_us() {
+        test_remove_lc_paths(false);
+    }
+    
+    fn test_remove_lc_paths(stranded: bool) {
         let print = true; 
-        let stranded = false; 
-        let strandedness = Strandedness::Unstranded;
+        let strandedness = if stranded { Strandedness::Forward } else { Strandedness::Unstranded };
+
+        let (n_diff_uc, n_diff_c) = if stranded { (27, 8) } else { (27, 10) };
 
         let   correct = "ACGATCGATCGCGATCGTAGCTGACTGCTGACGTCTGACTACTGACTGATGCTAGCTATCGTGAC".as_bytes();
         let incorrect = "ACGATCGATCGCGATCGTAGCTGACTGCTGACGGCTGACTACTGACTGATGCTAGCTATCGTGAC".as_bytes();
@@ -3822,7 +3835,7 @@ mod test {
         let n_edges = unc_graph.iter_edges().count();
         unc_graph.remove_lc_paths(10, 10, 10.).unwrap();
         if print { unc_graph.to_dot("uncompressed_af-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
-        assert_eq!(n_edges - 27, unc_graph.iter_edges().count());
+        assert_eq!(n_edges - n_diff_uc, unc_graph.iter_edges().count());
 
         // test with compressed graph
         let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
@@ -3841,14 +3854,22 @@ mod test {
         let n_edges = c_graph.iter_edges().count();
         c_graph.remove_lc_paths(10, 10, 10.).unwrap();
         if print { c_graph.to_dot("compressed_af-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
-        assert_eq!(n_edges - 10, c_graph.iter_edges().count());
+        assert_eq!(n_edges - n_diff_c, c_graph.iter_edges().count());
     }
 
     #[test]
-    fn test_remove_ladders() {
+    fn test_remove_ladders_s() {
+        test_remove_ladders(true);
+    }
+
+    #[test]
+    fn test_remove_ladders_us() {
+        test_remove_ladders(false);
+    }
+
+    fn test_remove_ladders(stranded: bool) {
         let print = true; 
-        let stranded = false; 
-        let strandedness = Strandedness::Unstranded;
+        let strandedness = if stranded { Strandedness::Forward } else { Strandedness::Unstranded };
 
         let c_csv = if print { Some("c_ladders.csv") } else { None };
         let uc_csv = if print { Some("uc_ladders.csv") } else { None };
@@ -3931,12 +3952,20 @@ mod test {
         assert_eq!(n_edges - 6, c_graph.iter_edges().count());
     }
 
-    #[test]
-    fn test_remove_tips() {
 
+    #[test]
+    fn test_remove_tips_s() {
+        test_remove_tips(true);
+    }
+
+    #[test]
+    fn test_remove_tips_us() {
+        test_remove_tips(false);
+    }
+
+    fn test_remove_tips(stranded: bool) {
         let print = false;
-        let stranded = false;
-        let strandedness = Strandedness::Unstranded;
+        let strandedness = if stranded { Strandedness::Forward } else { Strandedness::Unstranded };
 
         let c_csv = if print { Some("c_tips.csv") } else { None };
         let uc_csv = if print { Some("uc_tips.csv") } else { None };

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2122,6 +2122,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // check if path has reached max length -> interrupt
                     if path_length > max_path {
+                        print!("interrupt, too long");
                         break;
                     }
                     
@@ -2150,6 +2151,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                             (out_cov, next_node_id, next_in_dir, cov_diff) = (Some(cov as f32), Some(*id), Some(*in_dir), new_cov_diff);
                         }
                     }
+                    
                     let (Some(out_cov), Some(next_node_id), Some(next_in_dir)) = (out_cov, next_node_id, next_in_dir) else { break; };
 
                     // check if we increase ladder state
@@ -2211,6 +2213,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         cov_sum += current_cov as u32;
                         cov_count += 1;
                     }
+
+                    println!("node: {current_node_id} - {:?}", current_node);
                 }
             }
 
@@ -2266,6 +2270,9 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
 
             let avg_cov_high_path = (cov_sum as f32 / cov_count as f32) as u32;
+
+            println!("paths: {:?}", possible_paths);
+            println!("tips: {:?}", tips);
 
             // check if we have found end nodes of possible paths by following high coverage paths
             // if so, remove path
@@ -3818,7 +3825,7 @@ mod test {
 
     #[test]
     fn test_remove_ladders() {
-        let print = false; 
+        let print = true; 
         let stranded = false; 
         let strandedness = Strandedness::Unstranded;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1724,7 +1724,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     {
         // check we do indeed have quality and graph is stranded
         if self.get_node(0).data().quality().is_none() { return Err(String::from("no quality scores available")); }
-        if !self.base.stranded { return Err(String::from("graph must be stranded to remove ladders")) };
 
         // iterate over all nodes and look in both directions if there is a low quality node splitting off
         for (node_id, out_dir) in (0..self.len()).flat_map(|id| [(id, Dir::Right), (id, Dir::Left)]) {
@@ -1739,7 +1738,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             // get qualities 
             let nb_qualities = out_edges
                 .iter()
-                .map(|(_, nb_id, _, _)| (*nb_id, self
+                .map(|(_, nb_id, nb_in_dir, _)| (*nb_id, *nb_in_dir, self
                     .get_node(*nb_id)
                     .data()
                     .quality()
@@ -1748,7 +1747,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
             // check for good neighbor
             let has_good_nb = nb_qualities.iter()
-                .any(|(_, quality)| *quality >= min_quality);
+                .any(|(_, _, quality)| *quality >= min_quality);
 
             if !has_good_nb {
                 // split but no good path, move on
@@ -1756,9 +1755,9 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
 
             // remove split with low quality
-            for (nb_id, _) in nb_qualities.iter().filter(|(_, quality)| *quality < min_quality ) {
-                let path = vec![node_id, *nb_id];
-                if self.remove_path(path, out_dir).is_err() {
+            for (nb_id, nb_in_dir, _) in nb_qualities.iter().filter(|(_, _, quality)| *quality < min_quality ) {
+                let path = vec![(node_id, out_dir), (*nb_id, *nb_in_dir)];
+                if self.remove_path(path).is_err() {
                     warn!("lq tip path could not be removed")
                 }
             }
@@ -1781,22 +1780,20 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
         // iterate over nodes
         for (node_id, out_dir) in (0..self.len()).flat_map(|id| [(id, Dir::Right), (id, Dir::Left)]) {
-            let in_dir = out_dir.flip();
-
             // check if node has multile outs to the right, at least one with bad quality and one with good quality
             let node_out_edges = self.get_node(node_id).edges(out_dir);
 
             let good_neighbors = node_out_edges.iter()
-                .map(|(_, target_id, _, _)| *target_id)
-                .filter(|target_id| self.get_node(*target_id)
+                .map(|(_, target_id, target_in_dir, _)| (*target_id, target_in_dir))
+                .filter(|(target_id, _)| self.get_node(*target_id)
                     .data()
                     .quality()
                     .unwrap() >= min_quality
                 ).collect::<Vec<_>>();
 
             let bad_neighbors = node_out_edges.iter()
-                .map(|(_, target_id, _, _)| *target_id)
-                .filter(|target_id| self.get_node(*target_id)
+                .map(|(_, target_id, target_in_dir, _)| (*target_id, target_in_dir))
+                .filter(|(target_id, _)| self.get_node(*target_id)
                     .data()
                     .quality()
                     .unwrap() < min_quality
@@ -1808,9 +1805,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             let mut possible_paths = Vec::new();
             let mut tips = Vec::new();
 
-            for bn in bad_neighbors {
+            for (bn, bn_in_dir) in bad_neighbors {
+                let mut current_in_dir = *bn_in_dir; // in an unstranded graph, the out dir can change
                 let mut current_node_id = bn;
-                let mut path_groups = vec![vec![node_id]];
+                let mut path_groups = vec![vec![(node_id, out_dir.flip())]];
                 let mut path_length = K::k() - 1;
 
                 let mut state = LadderState::Singular;
@@ -1818,7 +1816,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                 loop {
                     let current_node = self.get_node(current_node_id);
-                    let out_edges = current_node.edges(out_dir);
+                    let out_edges = current_node.edges(current_in_dir.flip());
 
                     // add current node length to path
                     path_length += current_node.len() - K::k() + 1;
@@ -1833,12 +1831,12 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // if in singular state now or before, add node to path
                     if matches!(state, LadderState::Singular) { 
-                        path_groups[path_index].push(current_node_id);
+                        path_groups[path_index].push((current_node_id, current_in_dir.flip()));
                     }
 
                     // check if we increase ladder state
                     let q_increase = (current_node.data().quality().unwrap() >= min_quality) & !q_state_high;
-                    let mult_increase = current_node.edges(in_dir).len() > 1;
+                    let mult_increase = current_node.edges(current_in_dir).len() > 1;
                     
                     if q_increase {
                         q_state_high = true
@@ -1866,7 +1864,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                             LadderState::Singular => (), // ignore
                             LadderState::Double => {
                                 state = LadderState::Singular;
-                                path_groups.push(vec![current_node_id]); // start new path group
+                                path_groups.push(vec![(current_node_id, current_in_dir)]); // start new path group
                             }
                         }
                     }
@@ -1888,9 +1886,9 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     // we have not met the conditions and keep moving
 
                     // find next node
-                    let next_node_id = if out_edges.len() == 1 {
-                        let (_, next_node_id, _, _) = out_edges[0];
-                        next_node_id
+                    let (next_node_id, next_in_dir)  = if out_edges.len() == 1 {
+                        let (_, next_node_id, next_in_dir, _) = out_edges[0];
+                        (next_node_id, next_in_dir)
                     } else if out_edges.is_empty() {
                         // dead end which has not qualified as tip
                         break;
@@ -1898,30 +1896,33 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         // choose the lowest quality path
 
                         let worst_neighbor = out_edges.iter()
-                            .map(|(_, target_id, _, _)| (*target_id, self.get_node(*target_id)
+                            .map(|(_, target_id, target_in_dir, _)| (*target_id, *target_in_dir, self.get_node(*target_id)
                                 .data()
                                 .quality()
-                                .unwrap()))
-                            .min_by(|(_, q_a), (_, q_b)| q_a.cmp(q_b));
+                                .unwrap())
+                            )
+                            .min_by(|(_, _, q_a), (_, _, q_b)| q_a.cmp(q_b));
 
-                        if let Some((worst_nb_id, _)) = worst_neighbor {
-                            worst_nb_id
+                        if let Some((worst_nb_id, worst_nb_inc_dir, _)) = worst_neighbor {
+                            (worst_nb_id, worst_nb_inc_dir)
                         } else {
                             break;
                         }
                     };
 
                     current_node_id = next_node_id;
+                    current_in_dir = next_in_dir;
                 }
             }
 
-            let possible_targets = possible_paths.iter().map(|p| p.last().unwrap().last().unwrap()).collect::<Vec<_>>();
+            let possible_targets = possible_paths.iter().map(|p| p.last().unwrap().last().unwrap().0).collect::<Vec<_>>();
             let mut confirmed_targets = Vec::new();
             // follow the good quality paths until we reach a possible target node (or max search radius)
             // if we reached a target node, send bad path to be removed from graph
-            for gn in good_neighbors {
+            for (gn, gn_in_dir) in good_neighbors {
                 let mut path_length = K::k() - 1;
                 let mut current_node_id = gn;
+                let mut current_in_dir = *gn_in_dir;
 
                 loop {
                     // check if we have exceeded the search radius
@@ -1940,42 +1941,43 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     }
 
                     // look for next node
-                    let out_edges = current_node.edges(out_dir);
+                    let out_edges = current_node.edges(current_in_dir.flip());
 
-                    let next_node_id = if out_edges.len() == 1 {
-                        let (_, next_node_id, _, _) = out_edges[0];
-                        next_node_id
+                    let (next_node_id, next_in_dir) = if out_edges.len() == 1 {
+                        let (_, next_node_id, next_in_dir, _) = out_edges[0];
+                        (next_node_id, next_in_dir)
                     } else if out_edges.is_empty() {
                         // dead end, break
                         break;
                     } else {
                         // use node with highest quality
                         // TODO future: use read mapping?
-                        let good_neighbors = out_edges.iter()
-                            .map(|(_, target_id, _, _)| (*target_id, self.get_node(*target_id)
+                        let good_neighbor = out_edges.iter()
+                            .map(|(_, target_id, target_in_dir, _)| (*target_id, target_in_dir, self.get_node(*target_id)
                                 .data()
                                 .quality()
                                 .unwrap()))
-                            .max_by(|(_, q_a), (_, q_b)| q_a.cmp(q_b));
-                        if let Some((best_nb_id, _)) = good_neighbors {
-                            best_nb_id
+                            .max_by(|(_, _, q_a), (_, _, q_b)| q_a.cmp(q_b));
+                        if let Some((best_nb_id, best_nb_in_dir, _)) = good_neighbor {
+                            (best_nb_id, *best_nb_in_dir)
                         } else {
                             break;
                         }
                     };
 
                     current_node_id = next_node_id;
+                    current_in_dir = next_in_dir;
                 }
             }
 
             // check if we have found end nodes of possible paths by following good quality paths
             // if so, remove path
             for path_group in possible_paths {
-                let target = path_group.last().unwrap().last().unwrap();
+                let target = path_group.last().unwrap().last().unwrap().0;
 
-                if confirmed_targets.contains(target) {
+                if confirmed_targets.contains(&target) {
                     for path in path_group {
-                        if let Err(err) = self.remove_path(path.clone(), out_dir) {
+                        if let Err(err) = self.remove_path(path.clone()) {
                             warn!("lq ladder partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
                         }
                     }
@@ -1985,7 +1987,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             // remove tip paths
             for path_group in tips {
                 let path = path_group.into_iter().next().expect("empty tip path found");
-                if let Err(err) = self.remove_path(path.clone(), out_dir) {
+                if let Err(err) = self.remove_path(path.clone()) {
                     warn!("lq tip partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
                 }
             }
@@ -2020,10 +2022,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             writeln!(wtr, "avg high cov,avg low cov,high truth ratio,low truth ratio").unwrap();
         }
 
-        // iterate over nodes
-        for node_id in 0..self.len() {
+        // iterate over nodes, check in both directions
+        for (node_id, out_dir) in (0..self.len()).flat_map(|id| [(id, Dir::Right), (id, Dir::Left)]) {
             // check if node has outgoing edge(s) with both high and low coverage
-            let outs = self.get_node(node_id).data().edge_mults().expect("should have em").right();
+            let outs = self.get_node(node_id).data().edge_mults().expect("should have em").single_dir(out_dir).edge_mults;
 
             let Some((out_max_base, &out_max_cov)) = outs.iter().rev().enumerate().filter(|&(_, &c)| c  > 0).max_by(|&(_b1, &c1), &(_b2, c2)| c1.cmp(c2)) else { continue };
             let smaller_outs = outs.iter().copied().rev().enumerate().filter(|&(_b, c)| (c > 0) & (out_max_cov > c)).collect::<Vec<_>>();
@@ -2033,18 +2035,18 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             if smaller_outs.is_empty() { continue; }
 
             // follow path with highest coverage until target length is reached
-            let Some((target_node, avg_high_cov, high_cc)) = self.follow_ladder_path_high(node_id, out_max_base as u8, out_max_cov) else { continue; };
+            let Some((target_node, avg_high_cov, high_cc)) = self.follow_ladder_path_high(node_id, out_max_base as u8, out_max_cov, out_dir) else { continue; };
             
             // check all small outs
             for (s_base, s_cov) in smaller_outs {
-                let Some((target_paths, avg_low_cov, low_cc)) = self.follow_ladder_path_low(node_id, s_base as u8, s_cov) else { continue; };
-                let other_target_node = *target_paths.last().expect("should have at least one element").last().expect("should have at least two elements");
+                let Some((target_paths, avg_low_cov, low_cc)) = self.follow_ladder_path_low(node_id, s_base as u8, s_cov, out_dir) else { continue; };
+                let other_target_node = target_paths.last().expect("should have at least one element").last().expect("should have at least two elements").0;
 
                 if target_node == other_target_node {
                     // the two paths landed on the same node -> remove all edges in the low coverage path
                     if (s_cov * min_diff_factor <= out_max_cov) & (avg_low_cov <= max_avg_low_cov) {
                         for path in target_paths.iter() {
-                            if self.remove_path(path.clone(), Dir::Right).is_err() {
+                            if self.remove_path(path.clone()).is_err() {
                                 warn!("removing ladders: partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
                             }
                         } 
@@ -2061,7 +2063,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     }
 
     /// follow the presumably erroneous ladder path with low coverage
-    fn follow_ladder_path_low<DI>(&self, start_node_id: usize, start_ext: u8, start_cov: u32) -> Option<(Vec<Vec<usize>>, f32, f32)> 
+    fn follow_ladder_path_low<DI>(&self, start_node_id: usize, start_ext: u8, start_cov: u32, start_out_dir: Dir) -> Option<(Vec<Vec<(usize, Dir)>>, f32, f32)> 
     where SD: SummaryData<DI>
     {
         // state is switched if coverage rises by 20% + 2 (so it's at least 2 more)
@@ -2078,7 +2080,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         // path, including start and target node
         let mut paths = Vec::new();
         paths.push(Vec::new());
-        paths[0].push(start_node_id);
+        // add start node and start in dir as first element in path
+        paths[0].push((start_node_id, start_out_dir.flip()));
 
         let target_length = K::k();
         let mut path_length = 0;
@@ -2086,10 +2089,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
         // get fist next node
         let sequence = self.base.sequences.get(start_node_id);
-        let term_kmer: K = sequence.term_kmer(Dir::Right);
-        let next_kmer = term_kmer.extend(start_ext, Dir::Right);
-        let (mut current_node_id, _, _) = self.find_link(next_kmer, Dir::Right).expect("link should exist"); 
-        paths[0].push(current_node_id);
+        let term_kmer: K = sequence.term_kmer(start_out_dir);
+        let next_kmer = term_kmer.extend(start_ext, start_out_dir);
+        let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer, start_out_dir).expect("link should exist"); 
+        paths[0].push((current_node_id, current_in_dir));
 
         if self.check_edge_truth(start_node_id, current_node_id) {
             n_correct_edges += 1;
@@ -2123,25 +2126,26 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             let current_node = self.get_node(current_node_id);
             
             // get edges
-            let in_edges = current_node.l_edges();
-            let out_edges = current_node.r_edges();
+            let in_edges = current_node.edges(current_in_dir);
+            let out_edges = current_node.edges(current_in_dir.flip());
 
             // get coverage
             // edge cov must be available
-            let edge_coverages = current_node.data().edge_mults().expect("must have edge mults");
+            let out_edge_coverages = current_node.data().edge_mults().expect("must have edge mults").single_dir(current_in_dir.flip());
 
             // choose next edge by choosing coverage closest to current coverage
             let mut out_ext = None;
-            let mut out_node_id = None;
+            let mut next_node_id = None;
+            let mut next_in_dir = None;
             let mut cov_diff = i32::MAX;
-            for (e, id, _, _) in out_edges.iter() {
-                let cov = edge_coverages.edge_mult(*e, Dir::Right) as i32;
+            for (e, id, in_dir, _) in out_edges.iter() {
+                let cov = out_edge_coverages.edge_mult(*e) as i32;
                 let new_cov_diff = (current_cov as i32 - cov).abs();
                 if new_cov_diff < cov_diff {
-                    (out_ext, out_node_id, cov_diff) = (Some(*e), Some(*id), new_cov_diff);
+                    (out_ext, next_node_id, next_in_dir, cov_diff) = (Some(*e), Some(*id), Some(in_dir), new_cov_diff);
                 }
             }
-            let (Some(out_ext), Some(out_node_id)) = (out_ext, out_node_id) else { return None; };
+            let (Some(out_ext), Some(next_node_id), Some(next_in_dir)) = (out_ext, next_node_id, next_in_dir) else { return None; };
 
             // ideally, low path nodes should have one incoming and one outgoing edge
             // if two incoming edges, increase state from singular to double if possible
@@ -2162,14 +2166,14 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     LadderState::Singular => (), // could return None, but would kill if overlap is only one node long
                     LadderState::Double => {
                         state = LadderState::Singular;
-                        paths.push(vec![current_node_id]); // start new path
+                        paths.push(vec![(current_node_id, current_in_dir)]); // start new path
                     }
                 }
                 _ => return None
             }
 
-            // check coverage, in theoretical ladder, coverage should be uniform
-            let coverage = edge_coverages.edge_mult(out_ext, Dir::Right) as f32;
+            // check coverage, in theoretical ladder coverage should be uniform
+            let coverage = out_edge_coverages.edge_mult(out_ext) as f32;
             match state {
                 LadderState::Singular => {
                     // single state: check if next coverage is similar enough to current coverage
@@ -2187,7 +2191,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     if coverage < current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD {
                         // back in acceptable range
                         state = LadderState::Singular;
-                        paths.push(vec![current_node_id]); // start new path
+                        paths.push(vec![(current_node_id, current_in_dir)]); // start new path
                         current_cov = coverage;
                     } // else continue on 
                     // TODO check if better to also interrupt if coverage increases further
@@ -2197,7 +2201,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             // if state singular try to check if edge is "correct", add extra length of current node to it to account for compression
             match state {
                 LadderState::Singular => {
-                    if self.check_edge_truth(current_node_id, out_node_id) {
+                    if self.check_edge_truth(current_node_id, next_node_id) {
                         n_correct_edges += len;
                     }
                 }
@@ -2205,7 +2209,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
 
             // set current node id to next node to be visited
-            current_node_id = out_node_id;
+            current_node_id = next_node_id;
+            current_in_dir = *next_in_dir;
 
             // add current node to path, unless state is double
             match state {
@@ -2214,7 +2219,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     sum_path_cov += current_cov;
                     coverage_counter += 1;
                     let last_path = paths.len() - 1;
-                    paths[last_path].push(current_node_id); // add node to latest path
+                    paths[last_path].push((current_node_id, current_in_dir)); // add node to latest path
                 }
             }
         }
@@ -2222,7 +2227,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
     /// follow a path of the length 2*k - 1 by choosing the edges with the hightest coverage
     /// requres the graph to have edge mults
-    fn follow_ladder_path_high<DI>(&self, start_node_id: usize, start_ext: u8, start_cov: u32) -> Option<(usize, f32, f32)> 
+    fn follow_ladder_path_high<DI>(&self, start_node_id: usize, start_ext: u8, start_cov: u32, start_out_dir: Dir) -> Option<(usize, f32, f32)> 
     where SD: SummaryData<DI>
     {
 
@@ -2234,9 +2239,9 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
         // get fist next node
         let sequence = self.base.sequences.get(start_node_id);
-        let term_kmer: K = sequence.term_kmer(Dir::Right);
-        let next_kmer = term_kmer.extend(start_ext, Dir::Right);
-        let (mut current_node_id, _, _) = self.find_link(next_kmer, Dir::Right).expect("link should exist"); 
+        let term_kmer: K = sequence.term_kmer(start_out_dir);
+        let next_kmer = term_kmer.extend(start_ext, start_out_dir);
+        let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer,start_out_dir).expect("link should exist"); 
 
         if self.check_edge_truth(start_node_id, current_node_id) {
             n_correct_edges += 1;
@@ -2263,17 +2268,18 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
             // get next node id
             let sequence = self.base.sequences.get(current_node_id);
-            let term_kmer: K = sequence.term_kmer(Dir::Right);
-            let next_kmer = term_kmer.extend(max_cov_base as u8, Dir::Right);
-            let (out_node_id, _, _) = self.find_link(next_kmer, Dir::Right).expect("link should exist"); 
+            let term_kmer: K = sequence.term_kmer(current_in_dir.flip());
+            let next_kmer = term_kmer.extend(max_cov_base as u8, current_in_dir.flip());
+            let (next_node_id, next_in_dir, _) = self.find_link(next_kmer, current_in_dir.flip()).expect("link should exist"); 
 
             // try to check if edge is "correct", add extra length of current node to it to account for compression
-            if self.check_edge_truth(current_node_id, out_node_id) {
+            if self.check_edge_truth(current_node_id, next_node_id) {
                 n_correct_edges += len;
             }
 
             // set current node id to next node to be visited
-            current_node_id = out_node_id;
+            current_node_id = next_node_id;
+            current_in_dir = next_in_dir;
             sum_path_cov += max_cov;
             coverage_counter += 1;
         }
@@ -2330,7 +2336,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // remove path if coverage below threshold
                     if (s_cov * min_diff_factor <= out_max_cov) & (avg_tip_coverage <= max_avg_tip_cov) & (tip_len <= max_len) {
-                        self.remove_path(tip_path, dir)?;
+                        self.remove_path(tip_path)?;
                     }
                         
                     if let Some(wtr) = writer.as_mut() {
@@ -2344,7 +2350,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     }
 
     /// follow a tip path, returns path, average coverage and ration of correct to incorrect connections
-    fn follow_tip_path<DI>(&self, start_node_id: usize, start_ext: u8, start_cov: u32, dir: Dir) -> Option<(Vec<usize>, f32, f32, usize)> 
+    fn follow_tip_path<DI>(&self, start_node_id: usize, start_ext: u8, start_cov: u32, start_out_dir: Dir) -> Option<(Vec<(usize, Dir)>, f32, f32, usize)> 
     where 
         SD: SummaryData<DI>
     {
@@ -2353,17 +2359,17 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
         // path, including start and target node
         let mut path = Vec::new();
-        path.push(start_node_id);
+        path.push((start_node_id, start_out_dir));
 
         let mut path_length = 0;
         let mut n_correct_edges = 0;
 
         // get fist next node
         let sequence = self.base.sequences.get(start_node_id);
-        let term_kmer: K = sequence.term_kmer(dir);
-        let next_kmer = term_kmer.extend(start_ext, dir);
-        let (mut current_node_id, _, _) = self.find_link(next_kmer, dir).expect("link should exist"); 
-        path.push(current_node_id);
+        let term_kmer: K = sequence.term_kmer(start_out_dir);
+        let next_kmer = term_kmer.extend(start_ext, start_out_dir);
+        let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer, start_out_dir).expect("link should exist"); 
+        path.push((current_node_id, current_in_dir));
 
         if self.check_edge_truth(start_node_id, current_node_id) {
             n_correct_edges += 1;
@@ -2382,10 +2388,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             path_length += len;
 
             // low path nodes should have only one incoming and one outgoing edge
-            let in_edges = current_node.edges(dir.flip());
+            let in_edges = current_node.edges(start_out_dir.flip());
             if in_edges.len() != 1 { return None; }
 
-            let out_edges = current_node.edges(dir);
+            let out_edges = current_node.edges(start_out_dir);
             match out_edges.len() {
                 oe if oe > 1 => return None,
                 0 => return Some((path, (sum_path_cov / coverage_counter as f32), (n_correct_edges as f32 / path_length as f32), path_length)),
@@ -2393,9 +2399,9 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
 
             // if edge cov avalable, check for similarity
-            let (out_ext, out_node_id, _, _) = out_edges[0];
+            let (out_ext, next_node_id, next_in_dir, _) = out_edges[0];
             if let Some(em) = current_node.data().edge_mults() {
-                let coverage = em.edge_mult(out_ext, dir) as f32;
+                let coverage = em.edge_mult(out_ext, current_in_dir.flip()) as f32;
                 if coverage < current_cov - current_cov * COV_MARGIN - COV_ADD_MARGIN // extra two for small values
                     || coverage > current_cov + current_cov * COV_MARGIN + COV_ADD_MARGIN {
                     return None;
@@ -2405,98 +2411,56 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             }
 
             // try to check if edge is "correct", add extra length of current node to it to account for compression
-            if self.check_edge_truth(current_node_id, out_node_id) {
+            if self.check_edge_truth(current_node_id, next_node_id) {
                 n_correct_edges += len;
             }
 
             // set current node id to next node to be visited
-            current_node_id = out_node_id;
+            current_node_id = next_node_id;
+            current_in_dir = next_in_dir;
             sum_path_cov += current_cov;
             coverage_counter += 1;
             // add current node to path
-            path.push(current_node_id);
+            path.push((current_node_id, current_in_dir));
 
         }
     }
 
-    /// remove the edges (not the nodes) of a path in the graph
-    fn remove_path<DI>(&mut self, path: Vec<usize>, base_dir: Dir) -> Result<(), String> 
+    /// remove the edges (not the nodes) of a path in the graph, the path has to contain 
+    /// the node ID and the direction the path is coming from moving through the node
+    fn remove_path<DI>(&mut self, path: Vec<(usize, Dir)>) -> Result<(), String> 
     where SD: SummaryData<DI>
     {
         let mut path_iter = path.clone().into_iter();
-        let Some(mut current_node_id) = path_iter.next() else { return Ok(()); };
+        let Some((mut current_node_id, mut current_in_dir)) = path_iter.next() else { return Ok(()); };
 
         loop {
             // get next node id
-            let Some(next_node_id) = path_iter.next() else { return Ok(()); }; // whole path has been covered
-            // remove ext to the right of current node
-            let Some((out_base, _, _, _)) = self.get_node(current_node_id).edges(base_dir).iter().find(|&(_, id, _, _)| *id == next_node_id).copied()
-                else { return Err(format!(
-"no edge to remove (base dir)
-path: {:?}
-dir: {:?}
-node1:
-    id: {current_node_id}
-    left e: {:?}
-    right e: {:?}
-    exts: {:?}
-    data: {:?}
-node2:
-    id: {next_node_id}
-    left e: {:?}
-    right e: {:?}
-    exts: {:?}
-    data: {:?}",
-                path,
-                base_dir,
-                self.get_node(current_node_id).l_edges(),
-                self.get_node(current_node_id).r_edges(),
-                self.get_node(current_node_id).exts(),
-                self.get_node(current_node_id).data(),
-                self.get_node(next_node_id).l_edges(),
-                self.get_node(next_node_id).r_edges(),
-                self.get_node(next_node_id).exts(),
-                self.get_node(next_node_id).data(),
-                ))
-            };
+            let Some((next_node_id, next_in_dir)) = path_iter.next() else { return Ok(()); }; // whole path has been covered
+            // find base to remove ext leaving the current node
+            let Some((out_base, _, _, _)) = self.get_node(current_node_id).edges(current_in_dir.flip()).iter().find(|&(_, id, _, _)| *id == next_node_id).copied()
+                else {
+                    return Err( format!("no edge to remove (other dir), node 1:  {:?}, node 2: {:?}",
+                        self.get_node(current_node_id),
+                        self.get_node(next_node_id)
+                    ))
+                };
 
             // remove ext 
-            self.base.exts[current_node_id] = self.base.exts[current_node_id].remove(base_dir, out_base);
+            self.base.exts[current_node_id] = self.base.exts[current_node_id].remove(current_in_dir.flip(), out_base);
         
 
-            // remove ext to the left of the next node
-            let Some((in_base, _, _, _)) = self.get_node(next_node_id).edges(base_dir.flip()).iter().find(|&(_, id, _, _)| *id == current_node_id).copied() 
-                else { return Err( format!(
-"no edge to remove (other dir)
-path: {:?}
-dir: {:?}
-node1:
-    id: {current_node_id}
-    left e: {:?}
-    right e: {:?}
-    exts: {:?}
-    data: {:?}
-node2:
-    id: {next_node_id}
-    left e: {:?}
-    right e: {:?}
-    exts: {:?}
-    data: {:?}",
-                path,
-                base_dir,
-                self.get_node(current_node_id).l_edges(),
-                self.get_node(current_node_id).r_edges(),
-                self.get_node(current_node_id).exts(),
-                self.get_node(current_node_id).data(),
-                self.get_node(next_node_id).l_edges(),
-                self.get_node(next_node_id).r_edges(),
-                self.get_node(next_node_id).exts(),
-                self.get_node(next_node_id).data(),
+            // find base to remove ext entering the next node
+            let Some((in_base, _, _, _)) = self.get_node(next_node_id).edges(next_in_dir).iter().find(|&(_, id, _, _)| *id == current_node_id).copied() 
+                else { 
+                    return Err( format!("no edge to remove (other dir), node 1:  {:?}, node 2: {:?}",
+                    self.get_node(current_node_id),
+                    self.get_node(next_node_id)
                 ))
-            };
+                };
 
             // remove ext
-            self.base.exts[next_node_id] = self.base.exts[next_node_id].remove(base_dir.flip(), in_base); 
+            self.base.exts[next_node_id] = self.base.exts[next_node_id].remove(next_in_dir, in_base); 
 
             // use new exts to fix edge mults
             self.base.data[current_node_id].fix_edge_mults(self.base.exts[current_node_id]);
@@ -2504,6 +2468,7 @@ node2:
 
 
             current_node_id = next_node_id;
+            current_in_dir = next_in_dir;
         }
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2129,7 +2129,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // check if path has reached max length -> interrupt
                     if path_length > max_path {
-                        print!("interrupt, too long");
                         break;
                     }
                     

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -179,8 +179,7 @@ impl<K: Kmer, D> BaseGraph<K, D> {
                 kmers.push(self.sequences.get(*idx as usize).first_kmer());
                 sequences.push(self.sequences.get(*idx as usize).to_dna_string());
             }
-            println!("left kmers: {:?}", kmers);
-            println!("left seqs: {:?}", sequences);
+
             BoomHashMap::new(kmers, indices.clone())
         };
 
@@ -191,8 +190,7 @@ impl<K: Kmer, D> BaseGraph<K, D> {
                 kmers.push(self.sequences.get(*idx as usize).last_kmer());
                 sequences.push(self.sequences.get(*idx as usize).to_dna_string());
             }
-            println!("right kmers: {:?}", kmers);
-            println!("right seqs: {:?}", sequences);
+
             BoomHashMap::new(kmers, indices)
         };
 
@@ -1756,7 +1754,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
             // remove split with low quality
             for (nb_id, nb_in_dir, _) in nb_qualities.iter().filter(|(_, _, quality)| *quality < min_quality ) {
-                let path = vec![(node_id, out_dir), (*nb_id, *nb_in_dir)];
+                let path = vec![(node_id, out_dir.flip()), (*nb_id, *nb_in_dir)];
                 if self.remove_path(path).is_err() {
                     warn!("lq tip path could not be removed")
                 }
@@ -1773,14 +1771,13 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     {
         // check we do indeed have quality and graph is stranded
         if self.get_node(0).data().quality().is_none() { return Err(String::from("no quality scores available")); }
-        if !self.base.stranded { return Err(String::from("graph must be stranded to remove ladders")) };
 
         let min_path = 2 * K::k() - 1;
         let max_path = max_path_fac * K::k() - 1;
 
         // iterate over nodes
         for (node_id, out_dir) in (0..self.len()).flat_map(|id| [(id, Dir::Right), (id, Dir::Left)]) {
-            // check if node has multile outs to the right, at least one with bad quality and one with good quality
+            // check if node has multile outs, at least one with bad quality and one with good quality
             let node_out_edges = self.get_node(node_id).edges(out_dir);
 
             let good_neighbors = node_out_edges.iter()
@@ -1831,7 +1828,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // if in singular state now or before, add node to path
                     if matches!(state, LadderState::Singular) { 
-                        path_groups[path_index].push((current_node_id, current_in_dir.flip()));
+                        path_groups[path_index].push((current_node_id, current_in_dir));
                     }
 
                     // check if we increase ladder state
@@ -1977,7 +1974,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                 if confirmed_targets.contains(&target) {
                     for path in path_group {
-                        if let Err(err) = self.remove_path(path.clone()) {
+                        if let Err(_err) = self.remove_path(path.clone()) {
                             warn!("lq ladder partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
                         }
                     }
@@ -1987,14 +1984,12 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             // remove tip paths
             for path_group in tips {
                 let path = path_group.into_iter().next().expect("empty tip path found");
-                if let Err(err) = self.remove_path(path.clone()) {
+                if let Err(_err) = self.remove_path(path.clone()) {
                     warn!("lq tip partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
                 }
             }
 
-
         }
-
 
         Ok(())
     }
@@ -2015,7 +2010,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     {
         // interrupt if we dont have edge mults
         if self.get_node(0).data().edge_mults().is_none() { return Err(String::from("no edge mults available")) };
-        if !self.base.stranded { return Err(String::from("must be stranded")) };
 
         let mut writer = out_path.map(|path| BufWriter::new(File::create(path).expect("error creating ladder stats file")));
         if let Some(wtr) = writer.as_mut() {
@@ -2241,7 +2235,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         let sequence = self.base.sequences.get(start_node_id);
         let term_kmer: K = sequence.term_kmer(start_out_dir);
         let next_kmer = term_kmer.extend(start_ext, start_out_dir);
-        let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer,start_out_dir).expect("link should exist"); 
+        let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer, start_out_dir).expect("link should exist"); 
 
         if self.check_edge_truth(start_node_id, current_node_id) {
             n_correct_edges += 1;
@@ -2263,7 +2257,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             let current_node = self.get_node(current_node_id);
         
             // find outgoing edge with highest coverage
-            let em = current_node.data().edge_mults().expect("must have edge mults").right();
+            let em = current_node.data().edge_mults().expect("must have edge mults").single_dir(current_in_dir.flip()).edge_mults;
             let (max_cov_base, &max_cov) = em.iter().rev().enumerate().filter(|&(_, &c)| c > 0).max_by(|&(_b1, &c1), &(_b2, c2)| c1.cmp(c2))?;
 
             // get next node id
@@ -2295,7 +2289,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     {
         // interrupt if we dont have edge mults
         if self.get_node(0).data().edge_mults().is_none() { return Err(String::from("no edge mults available")) };
-        if !self.base.stranded { return Err(String::from("must be stranded")) };
 
         let mut writer = out_path.map(|path| BufWriter::new(File::create(path).expect("error creating ladder stats file")));
         if let Some(wtr) = writer.as_mut() {
@@ -2359,7 +2352,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
         // path, including start and target node
         let mut path = Vec::new();
-        path.push((start_node_id, start_out_dir));
+        path.push((start_node_id, start_out_dir.flip()));
 
         let mut path_length = 0;
         let mut n_correct_edges = 0;
@@ -2388,10 +2381,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             path_length += len;
 
             // low path nodes should have only one incoming and one outgoing edge
-            let in_edges = current_node.edges(start_out_dir.flip());
+            let in_edges = current_node.edges(current_in_dir);
             if in_edges.len() != 1 { return None; }
 
-            let out_edges = current_node.edges(start_out_dir);
+            let out_edges = current_node.edges(current_in_dir.flip());
             match out_edges.len() {
                 oe if oe > 1 => return None,
                 0 => return Some((path, (sum_path_cov / coverage_counter as f32), (n_correct_edges as f32 / path_length as f32), path_length)),
@@ -2410,6 +2403,8 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                 }
             }
 
+
+
             // try to check if edge is "correct", add extra length of current node to it to account for compression
             if self.check_edge_truth(current_node_id, next_node_id) {
                 n_correct_edges += len;
@@ -2422,7 +2417,6 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             coverage_counter += 1;
             // add current node to path
             path.push((current_node_id, current_in_dir));
-
         }
     }
 
@@ -3093,7 +3087,7 @@ impl<K: Kmer, D: Debug> Iterator for EdgeIter<'_, K, D> {
 mod test {
     use std::fs::remove_file;
 
-    use crate::{BaseQuality, Exts, build_test_graph, colors::Colors, compression::{CheckCompress, ScmapCompress, compress_kmers_with_hash, uncompressed_graph}, dna_string::DnaString, filter::filter_kmers, kmer::{Kmer6, Kmer16, Kmer22}, reads::{Reads, ReadsPaired}, serde::SerKmers, summarizer::{IDMapEMData, IDMapEMQualityData, IDTag, SampleInfo, SummaryConfig, TagsCountsData, TagsCountsSumData, Translator}, test::random_dna};
+    use crate::{BaseQuality, Exts, build_test_graph, colors::Colors, compression::{CheckCompress, ScmapCompress, compress_kmers_with_hash, uncompressed_graph}, dna_string::DnaString, filter::filter_kmers, kmer::{Kmer6, Kmer16, Kmer22}, reads::{Reads, ReadsPaired, Strandedness}, serde::SerKmers, summarizer::{IDMapEMData, IDMapEMQualityData, IDTag, SampleInfo, SummaryConfig, TagsCountsData, TagsCountsSumData, Translator}, test::random_dna};
 
     use crate::{summarizer::SummaryData, Dir};
 
@@ -3186,7 +3180,7 @@ mod test {
         assert_eq!(id_strings, new_id_strings);
     }
 
-    fn build_reads_quality_test() -> ReadsPaired<IDTag> {
+    fn build_reads_quality_test(strand: Strandedness) -> ReadsPaired<IDTag> {
         let correct1 = "CGATGCTGCTGATGCTGAGTCTGACGTATGCGATCGATCGACGATCGTACTAGCTGACTGTGCAGCTAGCTGACTGATCGTAGCTAGCTACGTGCTAGCTACTAGCACTGATGC";
         let qu_corr1 = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
         let incorrect1 =                                     "CGACGATCGTACTAGCTGACTGTGCAGCTAGCTGACTGATCGTGGCTAGCTACGTGCTAGCTA";
@@ -3205,7 +3199,7 @@ mod test {
         let qu_incorr5_tip =                                                             "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC-CCCCCCCCC";
 
 
-        let mut reads = Reads::new_with_quality(crate::reads::Strandedness::Forward);
+        let mut reads = Reads::new_with_quality(strand);
 
         for _i in 0..20 {
             reads.add_read(DnaString::from_acgt_bytes(correct1.as_bytes()), None, IDTag::new(1, 0), Some(qu_corr1.as_bytes()));
@@ -3227,18 +3221,19 @@ mod test {
 
     #[test]
     fn test_remove_lq_splits() {
-        let print = false;
+        let print = true;
+        let stranded = false;
 
         type K = Kmer16;
 
-        let seqs = build_reads_quality_test();
+        let seqs = build_reads_quality_test(Strandedness::Unstranded);
         let sample_info = SampleInfo::new(1, 0b111110, vec![1000, 10, 20, 20, 20, 20]);
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<IDMapEMQualityData, K, IDTag>(&seqs, &summary_config, false, 1., false);
 
 
         // make uncompressed graph
-        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), stranded).finish();
 
         // add "mapped" ids to graph
         for i in 0..unc_graph.len() {
@@ -3255,17 +3250,17 @@ mod test {
 
         let colors = Colors::new(&unc_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 7 });
 
-        if print { unc_graph.to_dot("uncompressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_bf-lq-splits.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = unc_graph.iter_edges().count();
         unc_graph.remove_lq_splits(BaseQuality::Medium).unwrap();
-        if print { unc_graph.to_dot("uncompressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_af-lq-splits.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
     
         let n_edges_af = unc_graph.iter_edges().count();
         assert_eq!(n_edges, n_edges_af + 11);
 
         // make compressed graph
         let spec = CheckCompress::new(|d: IDMapEMQualityData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(stranded, &spec, kmers, false, false).finish();
     
          // add "mapped" ids to graph
         for i in 0..c_graph.len() {
@@ -3282,10 +3277,10 @@ mod test {
 
         let colors = Colors::new(&c_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 7 });
 
-        if print { c_graph.to_dot("compressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_bf-lq-splits.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = c_graph.iter_edges().count();
         c_graph.remove_lq_splits(BaseQuality::Medium).unwrap();
-        if print { c_graph.to_dot("compressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_af-lq-splits.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
     
         let n_edges_af = c_graph.iter_edges().count();
         assert_eq!(n_edges, n_edges_af + 11);
@@ -3293,18 +3288,19 @@ mod test {
 
     #[test]
     fn test_remove_lq_ladders_tips() {
-        let print = false;
+        let print = true;
+        let stranded = false;
 
         type K = Kmer16;
 
-        let seqs = build_reads_quality_test();
+        let seqs = build_reads_quality_test(Strandedness::Unstranded);
         let sample_info = SampleInfo::new(1, 0b111110, vec![1000, 10, 20, 20, 20, 20]);
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<IDMapEMQualityData, K, IDTag>(&seqs, &summary_config, false, 1., false);
 
 
         // make uncompressed graph
-        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), stranded).finish();
 
         // add "mapped" ids to graph
         for i in 0..unc_graph.len() {
@@ -3321,17 +3317,17 @@ mod test {
 
         let colors = Colors::new(&unc_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 7 });
 
-        if print { unc_graph.to_dot("uncompressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_bf-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = unc_graph.iter_edges().count();
         unc_graph.remove_lq_ladders_tips(BaseQuality::Medium, 4).unwrap();
-        if print { unc_graph.to_dot("uncompressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_af-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
     
         let n_edges_af = unc_graph.iter_edges().count();
         assert_eq!(n_edges, n_edges_af + 90);
 
         // make compressed graph
         let spec = CheckCompress::new(|d: IDMapEMQualityData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(stranded, &spec, kmers, false, false).finish();
     
          // add "mapped" ids to graph
         for i in 0..c_graph.len() {
@@ -3348,10 +3344,10 @@ mod test {
 
         let colors = Colors::new(&c_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 7 });
 
-        if print { c_graph.to_dot("compressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_bf-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = c_graph.iter_edges().count();
         c_graph.remove_lq_ladders_tips(BaseQuality::Medium, 4).unwrap();
-        if print { c_graph.to_dot("compressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_af-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
     
         let n_edges_af = c_graph.iter_edges().count();
         assert_eq!(n_edges, n_edges_af + 15);
@@ -3359,7 +3355,10 @@ mod test {
 
     #[test]
     fn test_remove_ladders() {
-        let print = false; 
+        let print = true; 
+        let stranded = false; 
+        let strandedness = Strandedness::Unstranded;
+
         let c_csv = if print { Some("c_ladders.csv") } else { None };
         let uc_csv = if print { Some("uc_ladders.csv") } else { None };
 
@@ -3371,7 +3370,7 @@ mod test {
 
         let insertion = "ACGATCGATCGCGATCGATAGCTGACTGCTGACGTCTGACTACTGACTGATGCTAGCTATCGTGAC".as_bytes();
 
-        let mut reads = Reads::new(crate::reads::Strandedness::Forward);
+        let mut reads = Reads::new(strandedness);
         for _i in 0..1000 {
             reads.add_from_bytes(correct, None, IDTag::new(0, 0));
         }
@@ -3404,7 +3403,7 @@ mod test {
 
 
         // test with uncompressed graph
-        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), stranded).finish();
         // add ids to graph
         for i in 0..unc_graph.len() {
             let data = unc_graph.mut_data(i);
@@ -3415,15 +3414,15 @@ mod test {
             }
         }
         let colors = Colors::new(&unc_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 5 });
-        if print { unc_graph.to_dot("uncompressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_bf-lad.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = unc_graph.iter_edges().count();
         unc_graph.remove_ladders(10, 10., uc_csv).unwrap();
-        if print { unc_graph.to_dot("uncompressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_af-lad.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         assert_eq!(n_edges - 10, unc_graph.iter_edges().count());
 
         // test with compressed graph
         let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(stranded, &spec, kmers, false, false).finish();
         // add ids to graph
         for i in 0..c_graph.len() {
             let data = c_graph.mut_data(i);
@@ -3434,17 +3433,20 @@ mod test {
             }
         }
         let colors = Colors::new(&c_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 5 });
-        if print { c_graph.to_dot("compressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_bf-lad.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = c_graph.iter_edges().count();
         c_graph.remove_ladders(10, 10., c_csv).unwrap();
-        if print { c_graph.to_dot("compressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_af-lad.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         assert_eq!(n_edges - 6, c_graph.iter_edges().count());
     }
 
     #[test]
     fn test_remove_tips() {
 
-        let print = false;
+        let print = true;
+        let stranded = false;
+        let strandedness = Strandedness::Unstranded;
+
         let c_csv = if print { Some("c_tips.csv") } else { None };
         let uc_csv = if print { Some("uc_tips.csv") } else { None };
 
@@ -3454,7 +3456,7 @@ mod test {
 
 
 
-        let mut reads = Reads::new(crate::reads::Strandedness::Forward);
+        let mut reads = Reads::new(strandedness);
         for _i in 0..1000 {
             reads.add_from_bytes(correct, None, IDTag::new(0, 0));
         }
@@ -3474,7 +3476,7 @@ mod test {
 
 
         // test with uncompressed graph
-        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), stranded).finish();
         // add ids to graph
         for i in 0..unc_graph.len() {
             let data = unc_graph.mut_data(i);
@@ -3486,16 +3488,16 @@ mod test {
         }
 
         let colors = Colors::new(&unc_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 3 });
-        if print { unc_graph.to_dot("uncompressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_bf-tips.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = unc_graph.iter_edges().count();
         
         unc_graph.remove_tips(10, 10., uc_csv).unwrap();
-        if print { unc_graph.to_dot("uncompressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { unc_graph.to_dot("uncompressed_af-tips.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         assert_eq!(n_edges - 11, unc_graph.iter_edges().count());
 
         // test with compressed graph
         let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(stranded, &spec, kmers, false, false).finish();
         // add ids to graph
         for i in 0..c_graph.len() {
             let data = c_graph.mut_data(i);
@@ -3506,12 +3508,12 @@ mod test {
             }
         }
 
-        let colors = Colors::new(&c_graph, &summary_config, crate::colors::ColorMode::SampleGroups);
-        if print { c_graph.to_dot("compressed_bf.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        let colors = Colors::new(&c_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 3 });
+        if print { c_graph.to_dot("compressed_bf-tips.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = c_graph.iter_edges().count();
         
         c_graph.remove_tips(10, 10., c_csv).unwrap();
-        if print { c_graph.to_dot("compressed_af.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        if print { c_graph.to_dot("compressed_af-tips.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         assert_eq!(n_edges - 2, c_graph.iter_edges().count());
 
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -828,8 +828,7 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
             }
         }
 
-        // remove unncecessary memory from boxed slices
-        node_edge_transcript_ids.iter_mut().for_each(|emap| emap.shrink_to_fit());
+        // remove unncecessary memory from vector
         node_edge_transcript_ids.shrink_to_fit();
 
         Ok(node_edge_transcript_ids)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2113,8 +2113,11 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                 let mut cov_sum = start_out_cov;
                 let mut cov_count = 1;
 
+                println!("start node: {node_id}, out base: {start_out_base}, out cov: {start_out_cov}");
+
                 loop {
                     let current_node = self.get_node(current_node_id);
+                    println!("node: {current_node_id} - {:?}", current_node);
                     let out_edges = current_node.edges(current_in_dir.flip());
 
                     // add current node length to path
@@ -2138,9 +2141,10 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
 
                     // get coverage
                     // edge cov must be available
-                    let out_edge_coverages = current_node.data().edge_mults().expect("must have edge mults").single_dir(current_in_dir.flip());
+                    let edge_coverages = current_node.data().edge_mults().expect("must have edge mults");
+                    let out_edge_coverages = edge_coverages.single_dir(current_in_dir.flip());
 
-                    let mut out_cov = None;
+                    let mut closest_out_cov = None;
                     let mut next_node_id = None;
                     let mut next_in_dir = None;
                     let mut cov_diff = i32::MAX;
@@ -2148,19 +2152,47 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         let cov = out_edge_coverages.edge_mult(*base) as i32;
                         let new_cov_diff = (current_cov as i32 - cov).abs();
                         if new_cov_diff < cov_diff {
-                            (out_cov, next_node_id, next_in_dir, cov_diff) = (Some(cov as f32), Some(*id), Some(*in_dir), new_cov_diff);
+                            (closest_out_cov, next_node_id, next_in_dir, cov_diff) = (Some(cov as f32), Some(*id), Some(*in_dir), new_cov_diff);
                         }
                     }
-                    
-                    let (Some(out_cov), Some(next_node_id), Some(next_in_dir)) = (out_cov, next_node_id, next_in_dir) else { break; };
+
+                    println!("next node: {:?}, next in dir: {:?}, closest_out_cov: {:?}", next_node_id, next_in_dir, closest_out_cov);
+
+                    // check if coverage increases on high path, similar to c_increase check but with highest outgoing coverage and start cov
+                    // TODO check if better with min_diff_factor
+                    // TODO check if we should replace consts with min diff factor
+                    let highest_cov = out_edge_coverages.edge_mults.iter().max().unwrap_or(&0);
+                    let coverage_req =  (*highest_cov as f32 > out_max_cov as f32 - out_max_cov as f32 * COV_STATE_FACTOR + COV_STATE_ADD) & !c_state_high; // higer coverage than last edge
+                    println!("highest out cov: {highest_cov}, coverage_req: {coverage_req}");
+
+                    // check if we have met end criterium -> save path
+                    let len_req = path_length >= min_path; // path long enough
+                    // path is a simple tip -> save as tip
+                    let is_tip = out_edges.is_empty() & (path_groups.len() == 1); // TODO maybe remove req 2 in future
+
+                    if coverage_req & len_req {
+                        possible_paths.push((path_groups, cov_sum as f32 / cov_count as f32));
+                        break;
+                    } else if is_tip {
+                        tips.push((path_groups, cov_sum as f32 / cov_count as f32));
+                        break;
+                    }
+
+                    // check if we have a next node: 
+                    let (Some(closest_out_cov), Some(next_node_id), Some(next_in_dir)) = (closest_out_cov, next_node_id, next_in_dir) else { 
+                        println!("interrupting bc no more nodes");
+                        break; 
+                    };
 
                     // check if we increase ladder state
-                    let c_increase = (out_cov > current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD) & !c_state_high;
+                    let c_increase = (closest_out_cov > current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD) & !c_state_high;
                     let mult_increase = current_node.edges(current_in_dir).len() > 1;
                     
                     if c_increase {
                         c_state_high = true
                     }
+
+                    println!("state: {:?}", state);
 
                     if c_increase | mult_increase {
                         match state {
@@ -2171,22 +2203,11 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         };
                     }
 
-                    // check if we have met end criterium -> save path
-                    let quality_req =  c_state_high; // high coverage
-                    let len_req = path_length >= min_path; // path long enough
-                    // path is a simple tip -> save as tip
-                    let is_tip = out_edges.is_empty() & (path_groups.len() == 1); // TODO maybe remove req 2 in future
-
-                    if quality_req & len_req {
-                        possible_paths.push((path_groups, cov_sum as f32 / cov_count as f32));
-                        break;
-                    } else if is_tip {
-                        tips.push((path_groups, cov_sum as f32 / cov_count as f32));
-                        break;
-                    }
+                    println!("state: {:?}", state);
 
                     // check if we decrease ladder state
-                    let c_decrease = (out_cov < current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD) & c_state_high;
+                    // do not check if coverage was already high bc state could be increased for just one node by inc edge
+                    let c_decrease = closest_out_cov < current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD; //& c_state_high;
                     let mult_decrease = out_edges.len() > 1;
 
                     if c_decrease {
@@ -2203,18 +2224,18 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                         }
                     }
 
+                    println!("state: {:?}", state);
+
                     // we have not met the conditions and keep moving
-                    current_cov = out_cov;
                     current_node_id = next_node_id;
                     current_in_dir = next_in_dir;
 
                     // if the ladder state is singular, use coverage for avg cov
                     if matches!(state, LadderState::Singular) {
+                        current_cov = closest_out_cov;
                         cov_sum += current_cov as u32;
                         cov_count += 1;
                     }
-
-                    println!("node: {current_node_id} - {:?}", current_node);
                 }
             }
 
@@ -3801,7 +3822,7 @@ mod test {
         let n_edges = unc_graph.iter_edges().count();
         unc_graph.remove_lc_paths(10, 10, 10.).unwrap();
         if print { unc_graph.to_dot("uncompressed_af-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
-        assert_eq!(n_edges - 10, unc_graph.iter_edges().count());
+        assert_eq!(n_edges - 27, unc_graph.iter_edges().count());
 
         // test with compressed graph
         let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
@@ -3820,7 +3841,7 @@ mod test {
         let n_edges = c_graph.iter_edges().count();
         c_graph.remove_lc_paths(10, 10, 10.).unwrap();
         if print { c_graph.to_dot("compressed_af-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
-        assert_eq!(n_edges - 6, c_graph.iter_edges().count());
+        assert_eq!(n_edges - 10, c_graph.iter_edges().count());
     }
 
     #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2863,7 +2863,21 @@ impl<K: Kmer, SD: Debug> Node<'_, K, SD>  {
             let count = em.edge_mult(base, dir);
             let penwidth = colors.edge_width(count);
 
-            format!("[color={color}, penwidth={penwidth}, label=\"{}: {count}\", weight={count}]", bits_to_base(base))
+            if let Some(emap) = self.data().mapped_edge_ids() {
+                // if available, also print IDs mapped to edges
+                let mapped_ids = emap.edge_map(base, dir);
+
+                // change color according to edge truth
+                let color = match incoming_dir {
+                    Dir::Left => if mapped_ids.is_empty() {"deepskyblue"} else {"blue"},
+                    Dir::Right => if mapped_ids.is_empty() {"salmon"} else {"red"},
+                };
+
+                format!("[color={color}, penwidth={penwidth}, label=\"{}: {count}, {:?}\", weight={count}]", bits_to_base(base), mapped_ids)
+            } else {
+                format!("[color={color}, penwidth={penwidth}, label=\"{}: {count}\", weight={count}]", bits_to_base(base))
+            }
+            
         } else {
             format!("[color={color}, penwidth={}]", colors.edge_width(1)) // since there should be no edge mults, this will return default value
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1739,14 +1739,14 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         Colors::new(self, config, color_mode)
     }
     
-    /// [`crate::EdgeMult`] will contain hanging edges if the nodes were filtered
-    pub fn fix_edge_mults<DI>(&mut self) 
+    /// [`crate::EdgeMult`] and [] will contain hanging edges if the nodes were filtered
+    pub fn fix_edge_data<DI>(&mut self) 
     where 
         SD: SummaryData<DI>
     {
         if self.get_node(0).data().edge_mults().is_some() {
             for i in 0..self.len() {
-                self.base.data[i].fix_edge_mults(self.base.exts[i]);
+                self.base.data[i].fix_edge_data(self.base.exts[i]);
             }
         }
     }
@@ -2791,9 +2791,9 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
             // remove ext
             self.base.exts[next_node_id] = self.base.exts[next_node_id].remove(next_in_dir, in_base); 
 
-            // use new exts to fix edge mults
-            self.base.data[current_node_id].fix_edge_mults(self.base.exts[current_node_id]);
-            self.base.data[next_node_id].fix_edge_mults(self.base.exts[next_node_id]);
+            // use new exts to fix edge mults and edge maps
+            self.base.data[current_node_id].fix_edge_data(self.base.exts[current_node_id]);
+            self.base.data[next_node_id].fix_edge_data(self.base.exts[next_node_id]);
 
 
             current_node_id = next_node_id;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -8,7 +8,6 @@ use bit_set::BitSet;
 use indicatif::ProgressBar;
 use indicatif::ProgressIterator;
 use indicatif::ProgressStyle;
-use itertools::chain;
 use itertools::enumerate;
 use log::warn;
 use log::{debug, trace};
@@ -30,7 +29,6 @@ use std::io::Write;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::path::Path;
-use std::usize;
 
 use boomphf::hashmap::BoomHashMap;
 
@@ -115,6 +113,13 @@ impl<K, D> BaseGraph<K, D> {
             data,
             phantom: PhantomData,
         }
+    }
+
+    /// shrink the storage of the `BaseGraph` to fit its contents
+    pub fn shrink_to_fit(&mut self) {
+        self.sequences.shrink_to_fit();
+        self.exts.shrink_to_fit();
+        self.data.shrink_to_fit();
     }
 }
 
@@ -217,6 +222,11 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
 
     pub fn is_empty(&self) -> bool {
         self.base.is_empty()
+    }
+
+    /// shrink the storage of the `DebruijnGraph` to fit its contents
+    pub fn shrink_to_fit(&mut self)  {
+        self.base.shrink_to_fit();
     }
 
     /// Get a node given it's `node_id`
@@ -3165,7 +3175,7 @@ mod test {
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<TagsData, Kmer16, _>(&reads_paired, &summary_config, false, 1., false);
 
-        let graph = uncompressed_graph(&kmers, true).finish();
+        let graph = uncompressed_graph(kmers, true).finish();
 
         let check_edges: Vec<(usize, Dir, u8, usize)> = vec![(0, Dir::Left, 2, 16), (0, Dir::Right, 1, 2), (1, Dir::Left, 0, 11), 
         (1, Dir::Right, 0, 16), (3, Dir::Left, 0, 13), (3, Dir::Right, 3, 10), (4, Dir::Left, 2, 21), (4, Dir::Right, 1, 17), (5, Dir::Left, 1, 27), 
@@ -3184,7 +3194,7 @@ mod test {
         let (_, ser_kmers, _) = build_test_graph::<Kmer22, u32, _>();
         let (kmers, mut translator, _) = ser_kmers.dissolve();
 
-        let unc_graph = uncompressed_graph(&kmers, true).finish();
+        let unc_graph = uncompressed_graph(kmers, true).finish();
 
         let mut id_strings = translator.id_translator().clone().unwrap().into_iter().map(|(name, _id)| name).collect::<Vec<_>>();
         id_strings.sort();
@@ -3256,7 +3266,7 @@ mod test {
 
 
         // make uncompressed graph
-        let mut unc_graph = uncompressed_graph(&kmers, true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
 
         // add "mapped" ids to graph
         for i in 0..unc_graph.len() {
@@ -3283,7 +3293,7 @@ mod test {
 
         // make compressed graph
         let spec = CheckCompress::new(|d: IDMapEMQualityData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, &kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
     
          // add "mapped" ids to graph
         for i in 0..c_graph.len() {
@@ -3322,7 +3332,7 @@ mod test {
 
 
         // make uncompressed graph
-        let mut unc_graph = uncompressed_graph(&kmers, true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
 
         // add "mapped" ids to graph
         for i in 0..unc_graph.len() {
@@ -3349,7 +3359,7 @@ mod test {
 
         // make compressed graph
         let spec = CheckCompress::new(|d: IDMapEMQualityData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, &kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
     
          // add "mapped" ids to graph
         for i in 0..c_graph.len() {
@@ -3422,7 +3432,7 @@ mod test {
 
 
         // test with uncompressed graph
-        let mut unc_graph = uncompressed_graph(&kmers, true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
         // add ids to graph
         for i in 0..unc_graph.len() {
             let data = unc_graph.mut_data(i);
@@ -3441,7 +3451,7 @@ mod test {
 
         // test with compressed graph
         let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, &kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
         // add ids to graph
         for i in 0..c_graph.len() {
             let data = c_graph.mut_data(i);
@@ -3492,7 +3502,7 @@ mod test {
 
 
         // test with uncompressed graph
-        let mut unc_graph = uncompressed_graph(&kmers, true).finish();
+        let mut unc_graph = uncompressed_graph(kmers.clone(), true).finish();
         // add ids to graph
         for i in 0..unc_graph.len() {
             let data = unc_graph.mut_data(i);
@@ -3513,7 +3523,7 @@ mod test {
 
         // test with compressed graph
         let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
-        let mut c_graph = compress_kmers_with_hash(true, &spec, &kmers, false, false).finish();
+        let mut c_graph = compress_kmers_with_hash(true, &spec, kmers, false, false).finish();
         // add ids to graph
         for i in 0..c_graph.len() {
             let data = c_graph.mut_data(i);
@@ -3547,7 +3557,7 @@ mod test {
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<TagsCountsData, Kmer6, _>(&reads_paired, &summary_config, false, 1., false);
 
-        let graph = compress_kmers_with_hash(false, &ScmapCompress::new(), &kmers, false, false).finish();
+        let graph = compress_kmers_with_hash(false, &ScmapCompress::new(), kmers, false, false).finish();
 
         graph.to_tsv("test_graph_unstranded.tsv", |node| node.data().print_ol(&Translator::empty(), &summary_config, None)).unwrap();
 
@@ -3563,7 +3573,7 @@ mod test {
         let summary_config = SummaryConfig::new(sample_info);
         let (kmers, _) = filter_kmers::<TagsCountsData, Kmer6, _>(&reads_paired, &summary_config, false, 1., false);
 
-        let graph = compress_kmers_with_hash(true, &ScmapCompress::new(), &kmers, false, false).finish();
+        let graph = compress_kmers_with_hash(true, &ScmapCompress::new(), kmers, false, false).finish();
 
         graph.to_tsv("test_graph_stranded.tsv", |node| node.data().print_ol(&Translator::empty(), &summary_config, None)).unwrap();
     

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -721,9 +721,6 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
     where 
         P: AsRef<Path>
     {
-        // return err if not stranded
-        if !self.base.stranded { return Err("graph has to be stranded".to_string()) };
-
         let reader = fasta::Reader::new(BufReader::new(File::open(path).unwrap()));
         let mut node_transcript_ids = vec![Vec::new(); self.len()];
 
@@ -756,9 +753,19 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
             // iterate over k-mers in transcript and find each one in the graph
             let sequence = DnaString::from_acgt_bytes(record.seq());
             for kmer in sequence.iter_kmers::<K>() {
-                if let Some(node) = self.search_kmer(kmer, Dir::Right) {
-                    node_transcript_ids[node].push(gene_id);
+                if self.base.stranded {
+                    if let Some(node) = self.search_kmer(kmer, Dir::Right) {
+                        node_transcript_ids[node].push(gene_id);
+                    }
+                } else {
+                    // graph is not stranded, look for both the k-mer ansd its reverse complement
+                    if let Some(node) = self.search_kmer(kmer, Dir::Right) {
+                        node_transcript_ids[node].push(gene_id);
+                    } else if let Some(node) = self.search_kmer(kmer.rc(), Dir::Right) {
+                        node_transcript_ids[node].push(gene_id);
+                    }
                 }
+                
             }
         }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3355,7 +3355,7 @@ mod test {
 
     #[test]
     fn test_remove_lq_splits() {
-        let print = true;
+        let print = false;
         let stranded = false;
 
         type K = Kmer16;
@@ -3422,7 +3422,7 @@ mod test {
 
     #[test]
     fn test_remove_lq_ladders_tips() {
-        let print = true;
+        let print = false;
         let stranded = false;
 
         type K = Kmer16;
@@ -3489,7 +3489,7 @@ mod test {
 
     #[test]
     fn test_remove_ladders() {
-        let print = true; 
+        let print = false; 
         let stranded = false; 
         let strandedness = Strandedness::Unstranded;
 
@@ -3577,7 +3577,7 @@ mod test {
     #[test]
     fn test_remove_tips() {
 
-        let print = true;
+        let print = false;
         let stranded = false;
         let strandedness = Strandedness::Unstranded;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2528,7 +2528,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
         }
     }
 
-    /// use mapped ids to check if the nodes of an edge were mapped to the same id
+    /// use ids mapped to nodes to check if the nodes of an edge were mapped to the same id
     /// returns false if mapped ids are not available
     pub fn check_edge_truth<DI>(&self, node_id_1: usize, node_id_2: usize) -> bool
     where 
@@ -2544,6 +2544,37 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     return true;
                 }
             }
+        }
+
+        false
+    }
+
+    /// use ids mapped to edges to check if the edge is a true edge
+    /// returns false if mapped ids are not available
+    pub fn check_edge_truth_emap<DI>(&self, node_id_1: usize, node_id_2: usize) -> bool
+    where 
+        SD: SummaryData<DI>
+    {
+        let mapped_ids_1 = self.get_node(node_id_1).data().mapped_edge_ids();
+
+        if let Some(emap) = mapped_ids_1 {
+            let node_1 = self.get_node(node_id_1);
+
+            // find node 2 in edges of node 1, check in both dirs
+            if let Some((out_base, _nb_id, _nb_inc_dir, _flip)) = node_1.l_edges().iter().find(|(_b, nb, _d, _f)| *nb == node_id_2) {
+                let edge_map = emap.edge_map(*out_base, Dir::Left);
+                if !edge_map.is_empty() {
+                    return true
+                }
+            } else if let Some((out_base, _nb_id, _nb_inc_dir, _flip)) = node_1.r_edges().iter().find(|(_b, nb, _d, _f)| *nb == node_id_2) {
+                let edge_map = emap.edge_map(*out_base, Dir::Right);
+                if !edge_map.is_empty() {
+                    return true
+                }
+            } else {
+                panic!("missing neighbor")
+            };
+
         }
 
         false

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1827,7 +1827,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
     }
 
     /// remove bubbles/ladders and tips in which one path has a quality lower than the given `min_quality`
-    pub fn remove_lq_ladders_tips<DI>(&mut self, min_quality: BaseQuality, max_path_fac: usize) -> Result<(), String>
+    pub fn remove_lq_paths<DI>(&mut self, min_quality: BaseQuality, max_path_fac: usize) -> Result<(), String>
     where
         SD: SummaryData<DI>
     {
@@ -1994,7 +1994,7 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                     path_length += current_node.len() - K::k() + 1;
 
                     // check if we have found a target
-                    if possible_targets.contains(&&current_node_id) {
+                    if possible_targets.contains(&current_node_id) {
                         confirmed_targets.push(current_node_id);
                         break;
                     }
@@ -2049,6 +2049,251 @@ impl<K: Kmer, SD: Debug> DebruijnGraph<K, SD> {
                 if let Err(_err) = self.remove_path(path.clone()) {
                     warn!("lq tip partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
                 }
+            }
+
+        }
+
+        Ok(())
+    }
+
+    /// remove bubbles/ladders and tips in which one path has a coverage lower than the other
+    pub fn remove_lc_paths<DI>(&mut self, max_path_fac: usize, min_diff_factor: u32, max_avg_low_cov: f32) -> Result<(), String>
+    where
+        SD: SummaryData<DI>
+    {
+        // state is switched if coverage rises by 20% + 2 (so it's at least 2 more)
+        // nodes with higher state are kept connected together
+        // tests have shown that increase in coverage does not necessarily indicate 
+        // a multiplicity change
+        // however, we are trying to avoid false positives - false negatives will 
+        // most likely be cut off from the component or would be removed by remove_tips
+        // as a next step
+        // increasing these values will increase the number of removed edges
+        const COV_STATE_FACTOR: f32 = 0.2; 
+        const COV_STATE_ADD: f32 = 2.;
+
+        // check we do indeed have the edge coverage
+        if self.get_node(0).data().edge_mults().is_none() { return Err(String::from("no quality scores available")); }
+
+        let min_path = 2 * K::k() - 1;
+        let max_path = max_path_fac * K::k() - 1;
+
+        // iterate over nodes
+        for (node_id, start_out_dir) in (0..self.len()).flat_map(|id| [(id, Dir::Right), (id, Dir::Left)]) {
+
+            let node = self.get_node(node_id);
+
+            // check if node has multile outs, at least one with bad quality and one with good quality
+            let node_out_coverages = node.data().edge_mults().expect("should have em").single_dir(start_out_dir).edge_mults;
+
+            let Some((out_max_base, &out_max_cov)) = node_out_coverages.iter().rev().enumerate().filter(|&(_, &c)| c  > 0).max_by(|&(_b1, &c1), &(_b2, c2)| c1.cmp(c2)) else { continue };
+            let smaller_outs = node_out_coverages.iter().copied().rev().enumerate().filter(|&(_b, c)| (c > 0) & (out_max_cov > c)).collect::<Vec<_>>();
+
+            if smaller_outs.is_empty() { continue; }
+
+            // follow the bad quality paths until we reach nodes with high quality again (or max search radius)
+            let mut possible_paths = Vec::new();
+            let mut tips = Vec::new();
+
+            let node_term_kmer = node.sequence().term_kmer::<K>(start_out_dir);
+
+            for (start_out_base, start_out_cov) in smaller_outs {
+                // get nb id
+                let next_kmer = node_term_kmer.extend(start_out_base as u8, start_out_dir);
+                let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer, start_out_dir).expect("link should exist"); 
+
+                let mut current_cov = start_out_cov as f32;
+
+                let mut path_groups = vec![vec![(node_id, start_out_dir.flip())]];
+                let mut path_length = K::k() - 1;
+
+                let mut state = LadderState::Singular;
+                let mut c_state_high = false;
+
+                let mut cov_sum = start_out_cov;
+                let mut cov_count = 1;
+
+                loop {
+                    let current_node = self.get_node(current_node_id);
+                    let out_edges = current_node.edges(current_in_dir.flip());
+
+                    // add current node length to path
+                    path_length += current_node.len() - K::k() + 1;
+
+                    // check if path has reached max length -> interrupt
+                    if path_length > max_path {
+                        break;
+                    }
+                    
+                    // check state and add current node to path
+                    let path_index = path_groups.len() - 1;
+
+                    // if in singular state now or before, add node to path
+                    if matches!(state, LadderState::Singular) { 
+                        path_groups[path_index].push((current_node_id, current_in_dir));
+                    }
+
+                    // choose next edge by choosing coverage closest to current coverage
+
+                    // get coverage
+                    // edge cov must be available
+                    let out_edge_coverages = current_node.data().edge_mults().expect("must have edge mults").single_dir(current_in_dir.flip());
+
+                    let mut out_cov = None;
+                    let mut next_node_id = None;
+                    let mut next_in_dir = None;
+                    let mut cov_diff = i32::MAX;
+                    for (base, id, in_dir, _) in out_edges.iter() {
+                        let cov = out_edge_coverages.edge_mult(*base) as i32;
+                        let new_cov_diff = (current_cov as i32 - cov).abs();
+                        if new_cov_diff < cov_diff {
+                            (out_cov, next_node_id, next_in_dir, cov_diff) = (Some(cov as f32), Some(*id), Some(*in_dir), new_cov_diff);
+                        }
+                    }
+                    let (Some(out_cov), Some(next_node_id), Some(next_in_dir)) = (out_cov, next_node_id, next_in_dir) else { break; };
+
+                    // check if we increase ladder state
+                    let c_increase = (out_cov > current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD) & !c_state_high;
+                    let mult_increase = current_node.edges(current_in_dir).len() > 1;
+                    
+                    if c_increase {
+                        c_state_high = true
+                    }
+
+                    if c_increase | mult_increase {
+                        match state {
+                            LadderState::Singular => {
+                                state = LadderState::Double;
+                            }
+                            LadderState::Double => () // ignore
+                        };
+                    }
+
+                    // check if we have met end criterium -> save path
+                    let quality_req =  c_state_high; // high coverage
+                    let len_req = path_length >= min_path; // path long enough
+                    // path is a simple tip -> save as tip
+                    let is_tip = out_edges.is_empty() & (path_groups.len() == 1); // TODO maybe remove req 2 in future
+
+                    if quality_req & len_req {
+                        possible_paths.push((path_groups, cov_sum as f32 / cov_count as f32));
+                        break;
+                    } else if is_tip {
+                        tips.push((path_groups, cov_sum as f32 / cov_count as f32));
+                        break;
+                    }
+
+                    // check if we decrease ladder state
+                    let c_decrease = (out_cov < current_cov + current_cov * COV_STATE_FACTOR + COV_STATE_ADD) & c_state_high;
+                    let mult_decrease = out_edges.len() > 1;
+
+                    if c_decrease {
+                        c_state_high = false;
+                    }
+
+                    if c_decrease | mult_decrease {
+                        match state {
+                            LadderState::Singular => (), // ignore
+                            LadderState::Double => {
+                                state = LadderState::Singular;
+                                path_groups.push(vec![(current_node_id, current_in_dir)]); // start new path group
+                            }
+                        }
+                    }
+
+                    // we have not met the conditions and keep moving
+                    current_cov = out_cov;
+                    current_node_id = next_node_id;
+                    current_in_dir = next_in_dir;
+
+                    // if the ladder state is singular, use coverage for avg cov
+                    if matches!(state, LadderState::Singular) {
+                        cov_sum += current_cov as u32;
+                        cov_count += 1;
+                    }
+                }
+            }
+
+            let possible_targets = possible_paths.iter().map(|(p, _c)| p.last().unwrap().last().unwrap().0).collect::<Vec<_>>();
+            let mut confirmed_targets = Vec::new();
+
+            // follow the high coverage until we reach a possible target node (or max search radius)
+            // if we reached a target node, send bad path to be removed from graph
+            
+            let next_kmer = node_term_kmer.extend(out_max_base as u8, start_out_dir);
+            let (mut current_node_id, mut current_in_dir, _) = self.find_link(next_kmer, start_out_dir).expect("link should exist"); 
+
+            let mut path_length = K::k() - 1;
+            let mut current_cov = out_max_cov;
+
+            // track coverage 
+            let mut cov_sum = current_cov;
+            let mut cov_count = 1;
+
+            loop {
+                // check if we have exceeded the search radius
+                if path_length > max_path {
+                    break;
+                }
+
+                // add current node length to path length
+                let current_node = self.get_node(current_node_id);
+                path_length += current_node.len() - K::k() + 1;
+
+                // check if we have found a target
+                if possible_targets.contains(&current_node_id) {
+                    confirmed_targets.push(current_node_id);
+                    // keep going in case we find another one
+                }
+
+                // look for next node
+                let out_coverages = current_node.data().edge_mults().expect("must have edge mults").single_dir(current_in_dir.flip()).edge_mults;
+
+                // use node with highest coverage
+                // find highest coverage
+                let current_term_kmer = current_node.sequence().term_kmer::<K>(current_in_dir.flip());
+                let Some((next_out_base, next_out_cov)) = out_coverages.iter().rev().enumerate().filter(|&(_, &c)| c > 0).max_by(|&(_b1, &c1), &(_b2, c2)| c1.cmp(c2)) else { break };
+                let next_kmer = current_term_kmer.extend(next_out_base as u8, current_in_dir.flip());
+                let (next_node_id, next_in_dir, _) = self.find_link(next_kmer, current_in_dir.flip()).expect("link should exist"); 
+
+
+                current_node_id = next_node_id;
+                current_in_dir = next_in_dir;
+                current_cov = *next_out_cov;
+                cov_sum += current_cov;
+                cov_count += 1;
+
+            }
+
+            let avg_cov_high_path = (cov_sum as f32 / cov_count as f32) as u32;
+
+            // check if we have found end nodes of possible paths by following high coverage paths
+            // if so, remove path
+            for (path_group, avg_low_cov) in possible_paths {
+                let target = path_group.last().unwrap().last().unwrap().0;
+
+                let cov_valid = (avg_low_cov.round() as u32 * min_diff_factor <= avg_cov_high_path) & (avg_low_cov <= max_avg_low_cov);
+
+                if confirmed_targets.contains(&target) & cov_valid {
+                    for path in path_group {
+                        if let Err(_err) = self.remove_path(path.clone()) {
+                            warn!("lq ladder partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
+                        }
+                    }
+                }
+            }
+
+            // remove tip paths
+            for (path_group, avg_tip_cov) in tips {
+                let path = path_group.into_iter().next().expect("empty tip path found");
+                let cov_valid = (avg_tip_cov.round() as u32 * min_diff_factor <= avg_cov_high_path) & (avg_tip_cov <= max_avg_low_cov);
+
+                if cov_valid {
+                    if let Err(_err) = self.remove_path(path.clone()) {
+                        warn!("lq tip partial path could not be removed, likely cause: loop, edges were already removed. parital path: {:?}", path)
+                    }
+                }
+                
             }
 
         }
@@ -3421,7 +3666,7 @@ mod test {
     }
 
     #[test]
-    fn test_remove_lq_ladders_tips() {
+    fn test_remove_lq_paths() {
         let print = false;
         let stranded = false;
 
@@ -3453,7 +3698,7 @@ mod test {
 
         if print { unc_graph.to_dot("uncompressed_bf-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = unc_graph.iter_edges().count();
-        unc_graph.remove_lq_ladders_tips(BaseQuality::Medium, 4).unwrap();
+        unc_graph.remove_lq_paths(BaseQuality::Medium, 4).unwrap();
         if print { unc_graph.to_dot("uncompressed_af-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
     
         let n_edges_af = unc_graph.iter_edges().count();
@@ -3480,11 +3725,95 @@ mod test {
 
         if print { c_graph.to_dot("compressed_bf-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
         let n_edges = c_graph.iter_edges().count();
-        c_graph.remove_lq_ladders_tips(BaseQuality::Medium, 4).unwrap();
+        c_graph.remove_lq_paths(BaseQuality::Medium, 4).unwrap();
         if print { c_graph.to_dot("compressed_af-lq.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
     
         let n_edges_af = c_graph.iter_edges().count();
         assert_eq!(n_edges, n_edges_af + 15);
+    }
+
+    #[test]
+    fn test_remove_lc_paths() {
+        let print = true; 
+        let stranded = false; 
+        let strandedness = Strandedness::Unstranded;
+
+        let   correct = "ACGATCGATCGCGATCGTAGCTGACTGCTGACGTCTGACTACTGACTGATGCTAGCTATCGTGAC".as_bytes();
+        let incorrect = "ACGATCGATCGCGATCGTAGCTGACTGCTGACGGCTGACTACTGACTGATGCTAGCTATCGTGAC".as_bytes();
+        let incorrec2 = "TGACAGCTGACGGCTGACTACTACGTCACTGACGATGCTGACAC".as_bytes();
+        let incorrec3 = "AAAAAAAAAGCTGACTGCTGACGGCTG".as_bytes();
+        let incorrec4 = "ACGGCTGACTACTGACTGAAAAAAAAAAA".as_bytes();
+
+        let insertion = "ACGATCGATCGCGATCGATAGCTGACTGCTGACGTCTGACTACTGACTGATGCTAGCTATCGTGAC".as_bytes();
+
+        let mut reads = Reads::new(strandedness);
+        for _i in 0..1000 {
+            reads.add_from_bytes(correct, None, IDTag::new(0, 0));
+        }
+
+        for _i in 0..2 {
+            reads.add_from_bytes(incorrect, None, IDTag::new(1, 1)); // should be removed
+        }
+
+        for _i in 0..15 {
+            reads.add_from_bytes(incorrec2, None, IDTag::new(2, 2)); // should be removed
+        }
+
+        for _i in 0..25 {
+            reads.add_from_bytes(incorrec3, None, IDTag::new(3, 3)); // should be removed
+        }
+
+        for _i in 0..30 {
+            reads.add_from_bytes(incorrec4, None, IDTag::new(4, 4)); // should be removed
+        }
+
+
+        for _i in 0..1 {
+            reads.add_from_bytes(insertion, None, IDTag::new(1, 3)); // should not be removed
+        }
+
+        let seqs = ReadsPaired::Unpaired { reads };
+        let sample_info = SampleInfo::new(1, 0b111110, vec![1000, 10, 20, 20, 20, 20]);
+        let summary_config = SummaryConfig::new(sample_info);
+        let (kmers, _) = filter_kmers::<IDMapEMData, Kmer16, IDTag>(&seqs, &summary_config, false, 1., false);
+
+
+        // test with uncompressed graph
+        let mut unc_graph = uncompressed_graph(kmers.clone(), stranded).finish();
+        // add ids to graph
+        for i in 0..unc_graph.len() {
+            let data = unc_graph.mut_data(i);
+            if let Some(ids) = data.ids() {
+                if ids.contains(&0) {
+                    data.set_mapped_ids(vec![0].into());
+                }
+            }
+        }
+        let colors = Colors::new(&unc_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 5 });
+        if print { unc_graph.to_dot("uncompressed_bf-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        let n_edges = unc_graph.iter_edges().count();
+        unc_graph.remove_lc_paths(10, 10, 10.).unwrap();
+        if print { unc_graph.to_dot("uncompressed_af-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        assert_eq!(n_edges - 10, unc_graph.iter_edges().count());
+
+        // test with compressed graph
+        let spec = CheckCompress::new(|d: IDMapEMData, _| d, |d, d1| d.join_test(d1));
+        let mut c_graph = compress_kmers_with_hash(stranded, &spec, kmers, false, false).finish();
+        // add ids to graph
+        for i in 0..c_graph.len() {
+            let data = c_graph.mut_data(i);
+            if let Some(ids) = data.ids() {
+                if ids.contains(&0) {
+                    data.set_mapped_ids(vec![0].into());
+                }
+            }
+        }
+        let colors = Colors::new(&c_graph, &summary_config, crate::colors::ColorMode::IDS { n_ids: 5 });
+        if print { c_graph.to_dot("compressed_bf-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        let n_edges = c_graph.iter_edges().count();
+        c_graph.remove_lc_paths(10, 10, 10.).unwrap();
+        if print { c_graph.to_dot("compressed_af-lcp.dot", &|node| node.node_dot_default(&colors, &summary_config, &Translator::empty(), false, false), &|node, base, dir, flip| node.edge_dot_default(&colors, base, dir, flip)); }
+        assert_eq!(n_edges - 6, c_graph.iter_edges().count());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1328,6 +1328,11 @@ impl SingleDirEdgeMult {
         reverse.reverse();
         SingleDirEdgeMult::new(reverse)
     }
+
+    /// get the multiplicity of a certain edge
+    pub fn edge_mult(&self, base: u8) -> u32 {
+        self.edge_mults[(ALPHABET_SIZE as u8 - 1 - base) as usize]
+    }
 }
 
 // TODO add methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -962,6 +962,9 @@ impl Tags {
     /// encodes a sorted (!) Vec<Tag> and encodes it as a u64
     pub fn from_tag_vec(vec: Vec<Tag>) -> Self {
         let mut x = 0;
+        
+        // if the vector is empty, return an empty Tags
+        if vec.is_empty() { return Tags { val: 0 } }
 
         // panic if Tags would overflow
         if ( *vec.last().expect("vector empty when it shouldn't be") ) / 8 as Tag >= mem::size_of::<Tags>() as Tag { 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1182,7 +1182,6 @@ impl Debug for EdgeMult {
 impl Display for EdgeMult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let base = ["A", "C", "G", "T"];
-        writeln!(f)?;
         for (i, b) in (0..ALPHABET_SIZE).rev().zip(base) {
             writeln!(f, "{}: {} | {}", 
                 b, 
@@ -1459,7 +1458,6 @@ impl Debug for EdgeMap {
 impl Display for EdgeMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let base = ["A", "C", "G", "T"];
-        writeln!(f)?;
         for (i, b) in (0..ALPHABET_SIZE).rev().zip(base) {
             writeln!(f, "{}: {:?} | {:?}", 
                 b, 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1179,6 +1179,7 @@ impl Debug for EdgeMult {
 impl Display for EdgeMult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let base = ["A", "C", "G", "T"];
+        writeln!(f)?;
         for (i, b) in (0..ALPHABET_SIZE).rev().zip(base) {
             writeln!(f, "{}: {} | {}", 
                 b, 
@@ -1356,11 +1357,7 @@ impl EdgeMap {
         EdgeMap { edge_maps }
     }
 
-    fn set_edge_map(&mut self, edge_map: Box<[ID]>, base: u8, dir: Dir) {
-        self.edge_maps[dir.index(base) as usize] = edge_map;
-    }
-
-    fn edge_map(&self, base: u8, dir: Dir) -> &Box<[ID]>{
+    fn edge_map(&self, base: u8, dir: Dir) -> &[ID] {
         &self.edge_maps[dir.index(base) as usize]
     }
 
@@ -1368,14 +1365,7 @@ impl EdgeMap {
         self.edge_maps[index] = edge_map;
     }
 
-    fn add_id_to_edge_map(&mut self, id: ID, base: u8, dir: Dir) {
-        let mut em = self.edge_maps[dir.index(base) as usize].to_vec();
-        em.push(id);
-
-        self.set_edge_map(em.into(), base, dir);
-    }
-
-     fn add_id_to_edge_map_at_index(&mut self, id: ID, index: usize) {
+    fn add_id_to_edge_map_at_index(&mut self, id: ID, index: usize) {
         let mut em = self.edge_maps[index].to_vec();
         em.push(id);
 
@@ -1443,6 +1433,7 @@ impl Debug for EdgeMap {
 impl Display for EdgeMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let base = ["A", "C", "G", "T"];
+        writeln!(f)?;
         for (i, b) in (0..ALPHABET_SIZE).rev().zip(base) {
             writeln!(f, "{}: {:?} | {:?}", 
                 b, 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1412,12 +1412,27 @@ impl EdgeMap {
         heap
     }
 
-    pub fn combine(left: &EdgeMap, right: &EdgeMap) -> EdgeMap {
-        let mut combined = EdgeMap::default().edge_maps;
-        (0..ALPHABET_SIZE).for_each(|i| combined[i] = right.edge_maps[i].clone());
-        (ALPHABET_SIZE..(2*ALPHABET_SIZE)).for_each(|i| combined[i] = left.edge_maps[i].clone());
+    pub fn from_single_dirs(left: &Option<SingleDirEdgeMap>, right: &Option<SingleDirEdgeMap>) -> Option<EdgeMap> {
+        if let Some(l_em) = left {
+            if let Some(r_em) = right {
+                let mut combined = EdgeMap::default().edge_maps;
+                (0..ALPHABET_SIZE).for_each(|i| combined[i] = r_em.edge_maps[i].clone());
+                (0..ALPHABET_SIZE).for_each(|i| combined[i + ALPHABET_SIZE] = l_em.edge_maps[i].clone());
+        
+                return Some(EdgeMap::new(combined))
+            }
+        }
 
-        EdgeMap::new(combined)
+        None
+    }
+
+    pub fn single_dir(&self, dir: Dir) -> SingleDirEdgeMap {
+        let singe_dir: &[Box<[u16]>; 4] = match dir {
+            Dir::Left => self.edge_maps[ALPHABET_SIZE..(2*ALPHABET_SIZE)].try_into().expect("Error: slice has incorrect length"),
+            Dir::Right => self.edge_maps[0..ALPHABET_SIZE].try_into().expect("Error: slice has incorrect length"),
+        };
+
+        SingleDirEdgeMap::new(singe_dir.clone())
     }
 }
 
@@ -1451,6 +1466,28 @@ impl Display for EdgeMap {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SingleDirEdgeMap {
+    edge_maps: [Box<[ID]>; ALPHABET_SIZE]
+}
+
+impl SingleDirEdgeMap {
+    pub fn new(edge_maps: [Box<[ID]>; ALPHABET_SIZE]) -> Self {
+        SingleDirEdgeMap { edge_maps }
+    }
+
+    pub fn complement(&self) -> Self {
+        let mut reverse = self.edge_maps.clone();
+        reverse.reverse();
+        SingleDirEdgeMap::new(reverse)
+    }
+
+    /// get the IDs mapped to a certain edge
+    pub fn edge_map(&self, base: u8) -> &[ID] {
+        &self.edge_maps[(ALPHABET_SIZE as u8 - 1 - base) as usize]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1360,6 +1360,10 @@ impl EdgeMap {
         self.edge_maps[dir.index(base) as usize] = edge_map;
     }
 
+    fn edge_map(&self, base: u8, dir: Dir) -> &Box<[ID]>{
+        &self.edge_maps[dir.index(base) as usize]
+    }
+
     fn set_edge_map_at_index(&mut self, edge_map: Box<[ID]>, index: usize) {
         self.edge_maps[index] = edge_map;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1411,6 +1411,14 @@ impl EdgeMap {
 
         heap
     }
+
+    pub fn combine(left: &EdgeMap, right: &EdgeMap) -> EdgeMap {
+        let mut combined = EdgeMap::default().edge_maps;
+        (0..ALPHABET_SIZE).for_each(|i| combined[i] = right.edge_maps[i].clone());
+        (ALPHABET_SIZE..(2*ALPHABET_SIZE)).for_each(|i| combined[i] = left.edge_maps[i].clone());
+
+        EdgeMap::new(combined)
+    }
 }
 
 impl Default for EdgeMap {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1374,15 +1374,6 @@ impl EdgeMap {
         self.set_edge_map_at_index(em.into(), index);
     }
 
-    fn shrink_to_fit(&mut self) {
-        for mut emap in self.edge_maps.iter_mut() {
-            let mut emap_vec = emap.to_vec();
-            emap_vec.shrink_to_fit();
-
-            emap = &mut emap_vec.into(); // FIXME
-        }
-    }
-
     /// add an ID at an [`Exts`] to the `EdgeMap`
     pub fn add_id(&mut self, exts: Exts, id: ID) {
         let mut exts = exts.val;
@@ -1658,6 +1649,18 @@ impl<K: Kmer> Iterator for KLowestQualityIter<'_, K> {
     }
 }
 
+/// add the alignment buffer to a structure
+/// - `size_heap`: contents of boxes/vectors -> are stored separately and do not go into alignment calculation
+pub fn size_aligned(size_stack: usize, size_heap: usize, align: usize) -> usize {
+    let empty = size_stack % align;
+    let buffer = match empty {
+        0 => 0,
+        _ => align - empty
+    };
+
+    buffer + size_heap + size_stack
+}
+
 pub fn build_test_graph<K, SD, DI>() -> (SerReads<DI>, SerKmers<K, SD>, SerGraph<K, SD>)
 where
     K: Kmer +  Send + Sync,
@@ -1793,7 +1796,7 @@ where
 mod tests {
     use bimap::BiMap;
 
-    use crate::{kmer::{Kmer17, Kmer4}, summarizer::{Marker, Tag, Translator}, Dir, EdgeMult, Exts, Kmer, Tags, TagsCountsFormatter, TagsFormatter, ALPHABET_SIZE};
+    use crate::{ALPHABET_SIZE, Dir, EdgeMap, EdgeMult, Exts, Kmer, Tags, TagsCountsFormatter, TagsFormatter, kmer::{Kmer4, Kmer17}, size_aligned, summarizer::{ID, Marker, Tag, Translator}};
 
     #[test]
     fn test_dir_index() {
@@ -1868,6 +1871,51 @@ mod tests {
         // reverse complement
         em.rc();
         assert_eq!(em.edge_mults, [1, 0, 1, 1, 1, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_edge_map() {
+        let empty_emaps: [Box<[u16]>; 8] = Default::default();
+        let default_emap = EdgeMap::default();
+
+        let mut emap = EdgeMap::new(empty_emaps.clone());
+
+        assert!(emap.is_empty());
+
+        assert_eq!(emap.edge_maps, empty_emaps);
+        assert_eq!(emap, default_emap);
+
+        let m = vec![1, 2];
+        emap.set_edge_map_at_index(m.clone().into(), 1); // right G
+        let r = emap.edge_map(2, Dir::Right);
+
+        assert!(!emap.is_empty());
+
+        assert_eq!(&m, r);
+
+        emap.add_id_to_edge_map_at_index(3, 1);
+        let r = emap.edge_map(2, Dir::Right);
+        assert_eq!(&[1, 2, 3], r);
+
+        let exp_mem = 3*std::mem::size_of::<ID>();
+        let r_mem = emap.mem_heap();
+        assert_eq!(exp_mem, r_mem);
+
+        emap.add_id(Exts::new(0b01000010), 4); // right G and left C
+        assert_eq!(&[1, 2, 3, 4], emap.edge_map(2, Dir::Right));
+        assert_eq!(&[4], emap.edge_map(1, Dir::Left));
+
+        let left = emap.single_dir(Dir::Left);
+        let right = emap.single_dir(Dir::Right);
+        let new_emap = EdgeMap::from_single_dirs(&Some(left), &Some(right)).unwrap();
+        assert_eq!(emap, new_emap);
+
+        let mut clean_emap = EdgeMap::default();
+        clean_emap.add_id_to_edge_map_at_index(4, 6); // left C
+
+        emap.clean_edges(Exts::new(0b00000010));
+
+        assert_eq!(emap, clean_emap);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1429,12 +1429,25 @@ impl EdgeMap {
     }
 
     pub fn single_dir(&self, dir: Dir) -> SingleDirEdgeMap {
-        let singe_dir: &[Box<[u16]>; 4] = match dir {
+        let singe_dir: &[Box<[ID]>; 4] = match dir {
             Dir::Left => self.edge_maps[ALPHABET_SIZE..(2*ALPHABET_SIZE)].try_into().expect("Error: slice has incorrect length"),
             Dir::Right => self.edge_maps[0..ALPHABET_SIZE].try_into().expect("Error: slice has incorrect length"),
         };
 
         SingleDirEdgeMap::new(singe_dir.clone())
+    }
+
+    /// clean the edge maps by removing IDs that led to filtered kmers
+    /// based on a correct [`Exts`]
+    pub fn clean_edges(&mut self, exts: Exts) {
+        let mut exts = exts.val;
+        for index in (0..(2 * ALPHABET_SIZE)).rev() {
+            if exts.is_multiple_of(2) {
+                self.edge_maps[index] = [].into();
+            }
+            exts >>= 1;
+        }
+        
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use summarizer::Marker;
 use std::fmt::{self, Debug, Display};
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::mem;
+use std::{array, mem};
 use std::ops::Range;
 
 use crate::compression::{CheckCompress, compress_kmers_with_hash};
@@ -1332,6 +1332,87 @@ impl SingleDirEdgeMult {
     /// get the multiplicity of a certain edge
     pub fn edge_mult(&self, base: u8) -> u32 {
         self.edge_mults[(ALPHABET_SIZE as u8 - 1 - base) as usize]
+    }
+}
+
+// would be more intuitive with left and right switched but Exts were built this way
+/// mapped transcript/gene/chromosome IDs for each of the 8 possible edges
+/// indices: 
+/// 0: T right
+/// 1: G right
+/// 2: C right
+/// 3: A right
+/// 4: T left
+/// 5: G left
+/// 6: C left
+/// 7: A left
+#[derive(PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Clone)]
+pub struct EdgeMap {
+    edge_maps: [Box<[ID]>; 2*ALPHABET_SIZE],
+}
+
+impl EdgeMap {
+    pub fn new(edge_maps: [Box<[ID]>; 2*ALPHABET_SIZE]) -> EdgeMap {
+        EdgeMap { edge_maps }
+    }
+
+    fn set_edge_map(&mut self, edge_map: Box<[ID]>, base: u8, dir: Dir) {
+        self.edge_maps[dir.index(base) as usize] = edge_map;
+    }
+
+    fn set_edge_map_at_index(&mut self, edge_map: Box<[ID]>, index: usize) {
+        self.edge_maps[index] = edge_map;
+    }
+
+    fn add_id_to_edge_map(&mut self, id: ID, base: u8, dir: Dir) {
+        let mut em = self.edge_maps[dir.index(base) as usize].to_vec();
+        em.push(id);
+
+        self.set_edge_map(em.into(), base, dir);
+    }
+
+     fn add_id_to_edge_map_at_index(&mut self, id: ID, index: usize) {
+        let mut em = self.edge_maps[index].to_vec();
+        em.push(id);
+
+        self.set_edge_map_at_index(em.into(), index);
+    }
+
+    fn shrink_to_fit(&mut self) {
+        for mut emap in self.edge_maps.iter_mut() {
+            let mut emap_vec = emap.to_vec();
+            emap_vec.shrink_to_fit();
+
+            emap = &mut emap_vec.into(); // FIXME
+        }
+    }
+
+    /// add an ID at an [`Exts`] to the `EdgeMap`
+    fn add_id(&mut self, exts: Exts, id: ID) {
+        let mut exts = exts.val;
+        for index in (0..(2 * ALPHABET_SIZE)).rev() {
+            if !exts.is_multiple_of(2) {
+                self.add_id_to_edge_map_at_index(id, index);
+            }
+            exts >>= 1;
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        let mut empty = true;
+
+        for emap in self.edge_maps.iter() {
+            if !emap.is_empty() { empty = false }
+        }
+
+        empty
+    }
+}
+
+impl Default for EdgeMap {
+    fn default() -> Self {
+        let edge_maps = array::from_fn(|_n| Vec::new().into());
+        Self { edge_maps }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1355,18 +1355,22 @@ pub struct EdgeMap {
 }
 
 impl EdgeMap {
+    /// create a new [`EdgeMap`] by supplying the underlying mapped IDs.
     pub fn new(edge_maps: [Box<[ID]>; 2*ALPHABET_SIZE]) -> EdgeMap {
         EdgeMap { edge_maps }
     }
 
+    /// get the IDs mapped to the specified edge
     fn edge_map(&self, base: u8, dir: Dir) -> &[ID] {
         &self.edge_maps[dir.index(base) as usize]
     }
 
+    /// set the IDs mapped to the edge at the specified index
     fn set_edge_map_at_index(&mut self, edge_map: Box<[ID]>, index: usize) {
         self.edge_maps[index] = edge_map;
     }
 
+    /// add an ID to the edge at the specified index
     fn add_id_to_edge_map_at_index(&mut self, id: ID, index: usize) {
         let mut em = self.edge_maps[index].to_vec();
         em.push(id);
@@ -1374,7 +1378,7 @@ impl EdgeMap {
         self.set_edge_map_at_index(em.into(), index);
     }
 
-    /// add an ID at an [`Exts`] to the `EdgeMap`
+    /// add an ID at an [`Exts`] to the [`EdgeMap`]
     pub fn add_id(&mut self, exts: Exts, id: ID) {
         let mut exts = exts.val;
         for index in (0..(2 * ALPHABET_SIZE)).rev() {
@@ -1385,6 +1389,7 @@ impl EdgeMap {
         }
     }
 
+    /// returns true if the [`EdgeMap`] does not contain any IDs
     pub fn is_empty(&self) -> bool {
         let mut empty = true;
 
@@ -1395,6 +1400,8 @@ impl EdgeMap {
         empty
     }
 
+    /// returns the heap memory used by the [`EdgeMap`] - the stack memory size
+    /// is always 128 bytes (8 edges * (8 byte pointer + 8 byte length))
     pub fn mem_heap(&self) -> usize {
         let mut heap = 0;
 
@@ -1405,6 +1412,7 @@ impl EdgeMap {
         heap
     }
 
+    /// create an [`EdgeMap`] from two [`SingleDirEdgeMap`]s
     pub fn from_single_dirs(left: &Option<SingleDirEdgeMap>, right: &Option<SingleDirEdgeMap>) -> Option<EdgeMap> {
         if let Some(l_em) = left {
             if let Some(r_em) = right {
@@ -1419,6 +1427,7 @@ impl EdgeMap {
         None
     }
 
+    /// get the [`SingleDirEdgeMap`] in the specified [`Dir`]
     pub fn single_dir(&self, dir: Dir) -> SingleDirEdgeMap {
         let singe_dir: &[Box<[ID]>; 4] = match dir {
             Dir::Left => self.edge_maps[ALPHABET_SIZE..(2*ALPHABET_SIZE)].try_into().expect("Error: slice has incorrect length"),
@@ -1428,7 +1437,7 @@ impl EdgeMap {
         SingleDirEdgeMap::new(singe_dir.clone())
     }
 
-    /// clean the edge maps by removing IDs that led to filtered kmers
+    /// clean the edge maps by removing IDs mapped to edges that led to filtered kmers,
     /// based on a correct [`Exts`]
     pub fn clean_edges(&mut self, exts: Exts) {
         let mut exts = exts.val;
@@ -1474,6 +1483,13 @@ impl Display for EdgeMap {
     }
 }
 
+/// mapped transcript/gene/chromosome IDs for each of the 4 possible edges
+/// indices in one direction: 
+/// 
+/// 0: T 
+/// 1: G 
+/// 2: C 
+/// 3: A 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SingleDirEdgeMap {
     edge_maps: [Box<[ID]>; ALPHABET_SIZE]
@@ -1490,7 +1506,7 @@ impl SingleDirEdgeMap {
         SingleDirEdgeMap::new(reverse)
     }
 
-    /// get the IDs mapped to a certain edge
+    /// get the IDs mapped to the specified edge
     pub fn edge_map(&self, base: u8) -> &[ID] {
         &self.edge_maps[(ALPHABET_SIZE as u8 - 1 - base) as usize]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1875,7 +1875,7 @@ mod tests {
 
     #[test]
     fn test_edge_map() {
-        let empty_emaps: [Box<[u16]>; 8] = Default::default();
+        let empty_emaps: [Box<[ID]>; 8] = Default::default();
         let default_emap = EdgeMap::default();
 
         let mut emap = EdgeMap::new(empty_emaps.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub trait Kmer: Mer + Sized + Copy + PartialEq + PartialOrd + Eq + Ord + Hash {
 
     /// Test if this Kmer and it's reverse complement are the same
     fn is_palindrome(&self) -> bool {
-        self.len() % 2 == 0 && *self == self.rc()
+        self.len().is_multiple_of(2) && *self == self.rc()
     }
 
     /// Create a Kmer from the first K bytes of `bytes`, which must be encoded as the integers 0-4.
@@ -988,7 +988,7 @@ impl Tags {
         // do bit-wise right shifts trough u64
         // each time first digit is 1 (is an odd number), push i to vec
         for i in 0..(mem::size_of::<Tags>()*8) as Tag {
-            if x % 2 != 0 {
+            if !x.is_multiple_of(2) {
                 vec.push(i)
             }
             x >>= 1;
@@ -1006,7 +1006,7 @@ impl Tags {
         // iterate through bits of the u64
         for i in 0..(mem::size_of::<Tags>()*8) as Tag {
             // check if odd number: current first bit is 1
-            if x % 2 != 0 {
+            if !x.is_multiple_of(2) {
                 match str_map.get_by_right(&{ i }) {
                     Some(label) => vec.push(label),
                     None => panic!("tried to access label that does not exist!"),
@@ -1070,7 +1070,7 @@ impl Iterator for TagsIterator {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if self.i as usize == mem::size_of::<Tags>()*8 { return None }
-            let result = self.tags.val % 2 != 0;
+            let result = !self.tags.val.is_multiple_of(2);
             self.tags.val >>= 1;
             self.i += 1;
             if result { return Some(self.i - 1); }
@@ -1216,7 +1216,7 @@ impl EdgeMult {
     pub fn add_exts(&mut self, exts: Exts) {
         let mut exts = exts.val;
         for index in (0..(2 * ALPHABET_SIZE)).rev() {
-            if exts % 2 != 0 {
+            if !exts.is_multiple_of(2) {
                 self.edge_mults[index] += 1
             }
             exts >>= 1;
@@ -1263,7 +1263,7 @@ impl EdgeMult {
     pub fn clean_edges(&mut self, exts: Exts) {
         let mut exts = exts.val;
         for index in (0..(2 * ALPHABET_SIZE)).rev() {
-            if exts % 2 == 0 {
+            if exts.is_multiple_of(2) {
                 self.edge_mults[index] = 0;
             }
             exts >>= 1;
@@ -1388,7 +1388,7 @@ impl EdgeMap {
     }
 
     /// add an ID at an [`Exts`] to the `EdgeMap`
-    fn add_id(&mut self, exts: Exts, id: ID) {
+    pub fn add_id(&mut self, exts: Exts, id: ID) {
         let mut exts = exts.val;
         for index in (0..(2 * ALPHABET_SIZE)).rev() {
             if !exts.is_multiple_of(2) {
@@ -1398,7 +1398,7 @@ impl EdgeMap {
         }
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         let mut empty = true;
 
         for emap in self.edge_maps.iter() {
@@ -1407,12 +1407,47 @@ impl EdgeMap {
 
         empty
     }
+
+    pub fn mem_heap(&self) -> usize {
+        let mut heap = 0;
+
+        for emap in self.edge_maps.iter() {
+            heap += mem::size_of_val(&**emap);
+        }
+
+        heap
+    }
 }
 
 impl Default for EdgeMap {
     fn default() -> Self {
         let edge_maps = array::from_fn(|_n| Vec::new().into());
         Self { edge_maps }
+    }
+}
+
+impl Debug for EdgeMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let edge_f = ["A:", ", C:", ", G:", ", T:", " | A:", ", C:", ", G:", ", T:"];
+        for (ef, em) in edge_f.iter().zip(self.edge_maps.iter().rev()) {
+             write!(f, "{} {:?}", ef, em)?
+        }
+        Ok(())
+    }
+}
+
+impl Display for EdgeMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let base = ["A", "C", "G", "T"];
+        for (i, b) in (0..ALPHABET_SIZE).rev().zip(base) {
+            writeln!(f, "{}: {:?} | {:?}", 
+                b, 
+                self.edge_maps[i + ALPHABET_SIZE], 
+                self.edge_maps[i]
+            )?
+        }
+
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1608,7 +1608,7 @@ where
     let ser_kmers = SerKmers::new(kmers.clone(), translator.clone(), summary_config.clone());
 
     let comp_spec = CheckCompress::new(|d: SD, _| d, |d, d1| d.join_test(d1));
-    let graph = compress_kmers_with_hash(true, &comp_spec, &kmers, false, false).finish();
+    let graph = compress_kmers_with_hash(true, &comp_spec, kmers, false, false).finish();
     let ser_graph = SerGraph::new(graph, translator, summary_config);
 
     (ser_reads, ser_kmers, ser_graph)

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -2,7 +2,7 @@ use bimap::BiMap;
 use clap::ValueEnum;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use statrs::distribution::{ContinuousCDF, Normal, StudentsT};
-use crate::{BaseQuality, EdgeMult, Exts, Kmer, KmerDataItem, Tags, TagsCountsFormatter, TagsFormatter};
+use crate::{BaseQuality, EdgeMap, EdgeMult, Exts, Kmer, KmerDataItem, Tags, TagsCountsFormatter, TagsFormatter};
 use std::{cmp::min_by, collections::HashMap, error::Error, fmt::{Debug, Display}, mem};
 
 /// inner type for [`Tags`] and group markers
@@ -876,8 +876,12 @@ pub trait SummaryData<DI>: Clone + Debug + Send + Sync + PartialEq + Serialize +
     fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>);
     /// get a reference to the mapped ids,  returns `None` if data is insufficient
     fn mapped_ids(&self) -> Option<&[ID]>;
-    /// add mapped ids to the data
+    /// add mapped ids to the node data
     fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>);
+    /// get a reference to the IDs mapped to the node edges, returns `None` id data is insuffivient
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap>;
+    /// add mapped IDs to the node's edges
+    fn set_mapped_edge_ids(&mut self, mapped_edge_ids: EdgeMap);
     /// check if the data can be joined into one
     fn join_test(&self, other: &Self) -> bool;
     /// check if node is valid according to: min kmer obs, group fraction, p-value
@@ -932,6 +936,10 @@ impl SummaryData<Tag> for u32 {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -1023,9 +1031,13 @@ impl SummaryData<Tag> for Vec<Tag> {
 
     fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
 
-        fn mapped_ids(&self) -> Option<&[ID]> { None }
+    fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -1104,6 +1116,10 @@ impl SummaryData<IDTag> for IDData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -1185,6 +1201,10 @@ impl SummaryData<IDTag> for IDSumData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -1281,6 +1301,10 @@ impl SummaryData<Tag> for TagsData {
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self == other
     }
@@ -1372,6 +1396,10 @@ impl SummaryData<Tag> for TagsSumData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -1497,6 +1525,10 @@ impl SummaryData<Tag> for TagsCountsSumData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -1653,6 +1685,10 @@ impl SummaryData<Tag> for TagsCountsData {
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self == other
     }
@@ -1798,6 +1834,10 @@ impl SummaryData<Tag> for TagsCountsPData {
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self == other
     }
@@ -1942,6 +1982,10 @@ impl SummaryData<Tag> for TagsCountsEMData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
@@ -2095,6 +2139,10 @@ impl SummaryData<Tag> for TagsCountsPEMData{
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
@@ -2274,6 +2322,10 @@ impl SummaryData<Tag> for TagsCountsPEMQualityData{
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
             && self.tags == other.tags
@@ -2428,6 +2480,10 @@ impl SummaryData<IDTag> for IDTagsCountsData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -2611,6 +2667,10 @@ impl SummaryData<IDTag> for IDTagsCountsPEMData{
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
             && self.tags == other.tags
@@ -2714,6 +2774,10 @@ impl SummaryData<IDTag> for IDEMData{
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.ids == other.ids
@@ -2822,6 +2886,10 @@ impl SummaryData<IDTag> for IDMapEMData{
     fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>) {
         self.map_ids = mapped_ids
     }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.ids == other.ids 
@@ -2936,6 +3004,10 @@ impl SummaryData<IDTag> for IDMapEMQualityData{
     fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>) {
         self.map_ids = mapped_ids
     }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.ids == other.ids 
@@ -3053,6 +3125,10 @@ impl SummaryData<Tag> for SumMapEMQualityData{
         self.map_ids = mapped_ids
     }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self.sum == other.sum 
         && self.map_ids == other.map_ids
@@ -3094,18 +3170,20 @@ impl SummaryData<Tag> for SumMapEMQualityData{
 /// 
 /// Contains the IDs the k-mer was observed with, a placeholder for mapped ids, and edge multiplicites/coverage
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MapEMQualityData {
+pub struct MapEMEmapQualityData {
     map_ids: Box<[ID]>,
     edge_mults: EdgeMult,
+    edge_maps: EdgeMap,
     quality: BaseQuality
 }
 
-impl SummaryData<Tag> for MapEMQualityData{
+impl SummaryData<Tag> for MapEMEmapQualityData{
     fn print(&self, translator: &Translator, _: &SummaryConfig, id_group_translator: Option<&HashMap<ID, ID>>) -> String {
         let map_ids_format = id_format(&self.map_ids, translator, id_group_translator);
 
-        format!("mapped IDs: {}, quality: {}, edge coverage: {}", 
+        format!("mapped IDs (node): {}, mapped IDs (edges): {}, quality: {}, edge coverage: {}", 
             map_ids_format,
+            self.edge_maps,
             self.quality,
             self.edge_mults,
         ).replace("\"", "\'") // replace " with ' to avoid conflicts in dot file
@@ -3114,8 +3192,9 @@ impl SummaryData<Tag> for MapEMQualityData{
     fn print_ol(&self, translator: &Translator, _: &SummaryConfig, id_group_translator: Option<&HashMap<ID, ID>>) -> String {
         let map_ids_format = id_format(&self.map_ids, translator, id_group_translator);
 
-        format!("mapped IDs: {}, quality: {}, edge coverage: {:?}", 
+        format!("mapped IDs (node): {}, mapped IDs (edges): {:?}, quality: {}, edge coverage: {:?}", 
             map_ids_format,
+            self.edge_maps,
             self.quality,
             self.edge_mults
         ).replace("\"", "\'") // replace " with ' to avoid conflicts in dot file
@@ -3126,13 +3205,13 @@ impl SummaryData<Tag> for MapEMQualityData{
 
         let has_mapped = !self.map_ids.is_empty() as usize;
 
-        format!("\"mapped_ids\": {map_ids_format}, \"has_mapped_ids\": {has_mapped}, \"quality\": {}", self.quality as u8) // rempve " to avoid conflicts in json file
+        format!("\"mapped_ids_nodes\": {map_ids_format}, \"mapped_ids_edges\": \"{:?}\", \"has_mapped_ids\": {has_mapped}, \"quality\": {}", self.edge_maps, self.quality as u8) // rempve " to avoid conflicts in json file
     }
 
     fn tags(&self) -> Option<Tags> { None }
 
     fn mem(&self) -> usize {
-        mem::size_of_val(self) + mem::size_of_val(&*self.map_ids)
+        mem::size_of_val(self) + mem::size_of_val(&*self.map_ids) + self.edge_maps.mem_heap()
     }
 
     fn sum(&self) -> Option<usize> { None }
@@ -3169,9 +3248,18 @@ impl SummaryData<Tag> for MapEMQualityData{
         self.map_ids = mapped_ids
     }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> {
+        Some(&self.edge_maps)
+    }
+
+    fn set_mapped_edge_ids(&mut self, mapped_edge_ids: EdgeMap) {
+        self.edge_maps = mapped_edge_ids
+    }
+
     fn join_test(&self, other: &Self) -> bool {
         self.map_ids == other.map_ids
         && self.quality == other.quality
+        && self.edge_maps == other.edge_maps
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool { 
@@ -3191,16 +3279,11 @@ impl SummaryData<Tag> for MapEMQualityData{
 
         let valid = valid_counts(tags, Some(summary.sum), config) && valid_p && valid_q;
 
-        let sum = match config.significant {
-            Some(digits) => round_digits(summary.sum, digits),
-            None => summary.sum  
-        };
-
-        (valid, summary.all_exts, MapEMQualityData { map_ids: Vec::new().into(), edge_mults: summary.edge_mults, quality }) 
+        (valid, summary.all_exts, MapEMEmapQualityData { map_ids: Vec::new().into(), edge_mults: summary.edge_mults, edge_maps: EdgeMap::default(), quality }) 
     }
 
     fn summarizer() -> Summarizers {
-        Summarizers::MapEMQuality
+        Summarizers::MapEMEmapQuality
     }
 }
 
@@ -3263,6 +3346,10 @@ impl SummaryData<Tag> for GroupCountData {
     fn mapped_ids(&self) -> Option<&[ID]> { None }
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
+
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self == other
@@ -3362,6 +3449,10 @@ impl SummaryData<Tag> for RelCountData {
 
     fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
 
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
+
+    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
+
     fn join_test(&self, other: &Self) -> bool {
         self == other
     }
@@ -3430,7 +3521,7 @@ pub enum Summarizers {
     IDMapEM,
     IDMapEMQuality,
     SumMapEMQuality,
-    MapEMQuality,
+    MapEMEmapQuality,
     GroupCount,
     RelCount
 }

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -881,7 +881,7 @@ pub trait SummaryData<DI>: Clone + Debug + Send + Sync + PartialEq + Serialize +
     /// get a reference to the IDs mapped to the node edges, returns `None` id data is insuffivient
     fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
     /// add mapped IDs to the node's edges
-    fn set_mapped_edge_ids(&mut self, _mapped_edge_ids: EdgeMap) { }
+    fn set_mapped_edge_ids(&mut self, _mapped_edge_ids: Option<EdgeMap>) { }
     /// check if the data can be joined into one
     fn join_test(&self, other: &Self) -> bool { self == other }
     /// check if node is valid according to: min kmer obs, group fraction, p-value
@@ -1225,34 +1225,8 @@ impl SummaryData<Tag> for TagsSumData {
         Some(self.sum as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
     fn sample_count(&self) -> Option<usize> {
         Some(self.tags.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -1358,30 +1332,8 @@ impl SummaryData<Tag> for TagsCountsSumData {
         Some(self.sum as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
-
     fn sample_count(&self) -> Option<usize> {
         Some(self.counts.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
@@ -1508,8 +1460,6 @@ impl SummaryData<Tag> for TagsCountsData {
         Some(self.counts.iter().sum::<u32>() as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
-
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
         p_value(&self.tags.to_tag_vec(), &self.counts, config).ok()
     }
@@ -1521,26 +1471,6 @@ impl SummaryData<Tag> for TagsCountsData {
 
     fn sample_count(&self) -> Option<usize> {
         Some(self.counts.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -2721,8 +2651,6 @@ impl SummaryData<IDTag> for IDMapEMQualityData{
         self.map_ids = mapped_ids
     }
 
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
     fn join_test(&self, other: &Self) -> bool {
         self.ids == other.ids 
         && self.map_ids == other.map_ids
@@ -2940,8 +2868,8 @@ impl SummaryData<Tag> for MapEMEmapQualityData{
         Some(&self.edge_maps)
     }
 
-    fn set_mapped_edge_ids(&mut self, mapped_edge_ids: EdgeMap) {
-        self.edge_maps = mapped_edge_ids
+    fn set_mapped_edge_ids(&mut self, mapped_edge_ids: Option<EdgeMap>) {
+        self.edge_maps = mapped_edge_ids.expect("Error: no mapped edge IDs")
     }
 
     fn join_test(&self, other: &Self) -> bool {

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -872,7 +872,7 @@ pub trait SummaryData<DI>: Clone + Debug + Send + Sync + PartialEq + Serialize +
     /// get the quality of the node k-mer
     fn quality(&self) -> Option<BaseQuality> { None }
     /// fix the [`EdgeMult`] by removing hanging edges
-    fn fix_edge_mults(&mut self, _exts: Exts) { }
+    fn fix_edge_data(&mut self, _exts: Exts) { }
     /// set the edge mults
     fn set_edge_mults(&mut self, _edge_mults: Option<EdgeMult>) { }
     /// get a reference to the mapped ids,  returns `None` if data is insufficient
@@ -1728,7 +1728,7 @@ impl SummaryData<Tag> for TagsCountsEMData {
     }
 
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -1873,7 +1873,7 @@ impl SummaryData<Tag> for TagsCountsPEMData{
         Some(&self.edge_mults)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2045,7 +2045,7 @@ impl SummaryData<Tag> for TagsCountsPEMQualityData{
         Some(self.quality)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2360,7 +2360,7 @@ impl SummaryData<IDTag> for IDTagsCountsPEMData{
         Some(&self.edge_mults)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2448,7 +2448,7 @@ impl SummaryData<IDTag> for IDEMData{
         Some(&self.edge_mults)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2534,7 +2534,7 @@ impl SummaryData<IDTag> for IDMapEMData{
         Some(&self.edge_mults)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2636,7 +2636,7 @@ impl SummaryData<IDTag> for IDMapEMQualityData{
         Some(self.quality)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2742,7 +2742,7 @@ impl SummaryData<Tag> for SumMapEMQualityData{
         Some(self.quality)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
 
@@ -2849,8 +2849,9 @@ impl SummaryData<Tag> for MapEMEmapQualityData{
         Some(self.quality)
     }
 
-    fn fix_edge_mults(&mut self, exts: Exts) {
+    fn fix_edge_data(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
+        self.edge_maps.clean_edges(exts);
     }
 
     fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>) {

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -853,39 +853,39 @@ pub trait SummaryData<DI>: Clone + Debug + Send + Sync + PartialEq + Serialize +
     /// format the noda data in one line
     fn print_json(&self, translator: &Translator, config: &SummaryConfig, id_group_translator: Option<&HashMap<ID, ID>>) -> String;
     /// get `Tags` and the overall count, returns `None` if data is insufficient
-    fn tags(&self) -> Option<Tags>;
+    fn tags(&self) -> Option<Tags> { None }
     /// get the size of the structure, including contents of boxed slices
     fn mem(&self) -> usize;
     /// get the number of observations, returns `None` if data is insufficient
-    fn sum(&self) -> Option<usize>;
+    fn sum(&self) -> Option<usize> { None }
     /// get the IDs, returns `None` if data is insufficient
-    fn ids(&self) -> Option<&[ID]>;
+    fn ids(&self) -> Option<&[ID]> { None }
     /// get the p-value, returns `None` if data is insufficient
-    fn p_value(&self, config: &SummaryConfig) -> Option<f32>;
+    fn p_value(&self, _config: &SummaryConfig) -> Option<f32> { None }
     /// get the log2(fold change), returns `None` if data is insufficient
-    fn fold_change(&self, config: &SummaryConfig) -> Option<f32>;
+    fn fold_change(&self, _config: &SummaryConfig) -> Option<f32> { None }
     /// get the number of samples the sequence was observed in, returns `None` if data is insufficient
-    fn sample_count(&self) -> Option<usize>;
+    fn sample_count(&self) -> Option<usize> { None }
     /// get the coverage of the node edges
-    fn edge_mults(&self) -> Option<&EdgeMult>;
+    fn edge_mults(&self) -> Option<&EdgeMult> { None }
     /// get the quality of the node k-mer
-    fn quality(&self) -> Option<BaseQuality>;
+    fn quality(&self) -> Option<BaseQuality> { None }
     /// fix the [`EdgeMult`] by removing hanging edges
-    fn fix_edge_mults(&mut self, exts: Exts);
+    fn fix_edge_mults(&mut self, _exts: Exts) { }
     /// set the edge mults
-    fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>);
+    fn set_edge_mults(&mut self, _edge_mults: Option<EdgeMult>) { }
     /// get a reference to the mapped ids,  returns `None` if data is insufficient
-    fn mapped_ids(&self) -> Option<&[ID]>;
+    fn mapped_ids(&self) -> Option<&[ID]> { None }
     /// add mapped ids to the node data
-    fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>);
+    fn set_mapped_ids(&mut self, _mapped_ids: Box<[ID]>) { }
     /// get a reference to the IDs mapped to the node edges, returns `None` id data is insuffivient
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap>;
+    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
     /// add mapped IDs to the node's edges
-    fn set_mapped_edge_ids(&mut self, mapped_edge_ids: EdgeMap);
+    fn set_mapped_edge_ids(&mut self, _mapped_edge_ids: EdgeMap) { }
     /// check if the data can be joined into one
-    fn join_test(&self, other: &Self) -> bool;
+    fn join_test(&self, other: &Self) -> bool { self == other }
     /// check if node is valid according to: min kmer obs, group fraction, p-value
-    fn valid(&self, config: &SummaryConfig) -> bool;
+    fn valid(&self, _config: &SummaryConfig) -> bool { true }
     /// summarize k-mers
     fn summarize<K: Kmer, F: Iterator<Item = KmerDataItem<K, DI>>>(items: F, config: &SummaryConfig) -> (bool, Exts, Self);
     /// check summerizer kind
@@ -907,42 +907,12 @@ impl SummaryData<Tag> for u32 {
         format!("\"sum\": {}", self)
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::align_of_val(self)
     }
 
     fn sum(&self) -> Option<usize> {
         Some(*self as usize)
-    }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -1011,40 +981,8 @@ impl SummaryData<Tag> for Vec<Tag> {
         mem::size_of_val(&**self) + mem::size_of_val(self)
     }
 
-    fn sum(&self) -> Option<usize> { None }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
     fn sample_count(&self) -> Option<usize> {
         Some(self.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-    
-    fn fix_edge_mults(&mut self, _: Exts) { }
-
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
-    }
-
-    fn valid(&self, _: &SummaryConfig) -> bool {
-        true
     }
 
     fn summarize<K: Kmer, F: Iterator<Item = KmerDataItem<K, Tag>>>(items: F, config: &SummaryConfig) -> (bool, Exts, Self) {
@@ -1087,45 +1025,13 @@ impl SummaryData<IDTag> for IDData {
         format!("\"ids\": {}", id_format(&self.ids, translator, id_group_translator)) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.ids)
     }
 
-    fn sum(&self) -> Option<usize> { None }
-
     fn ids(&self) -> Option<&[ID]> {
         Some(&self.ids[..])
     }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
-    }
-
-    fn valid(&self, _: &SummaryConfig) -> bool { true }
 
     fn summarize<K: Kmer, F: Iterator<Item = KmerDataItem<K, IDTag>>>(items: F, config: &SummaryConfig) -> (bool, Exts, Self) {
                 let summary = summarize_tags_ids_edge_q(items, config);
@@ -1170,8 +1076,6 @@ impl SummaryData<IDTag> for IDSumData {
         format!("\"ids\": {}, \"sum\": {}", id_format(&self.ids, translator, id_group_translator), self.sum) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.ids)
     }
@@ -1182,32 +1086,6 @@ impl SummaryData<IDTag> for IDSumData {
 
     fn ids(&self) -> Option<&[ID]> {
         Some(&self.ids[..])
-    }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -1277,36 +1155,8 @@ impl SummaryData<Tag> for TagsData {
         mem::size_of_val(self)
     }
 
-    fn sum(&self) -> Option<usize> { None }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
     fn sample_count(&self) -> Option<usize> {
         Some(self.tags.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -1804,8 +1654,6 @@ impl SummaryData<Tag> for TagsCountsPData {
         Some(self.sum() as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
-
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
             Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
@@ -1820,26 +1668,6 @@ impl SummaryData<Tag> for TagsCountsPData {
     
     fn sample_count(&self) -> Option<usize> {
         Some(self.counts.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -1951,7 +1779,6 @@ impl SummaryData<Tag> for TagsCountsEMData {
         Some(self.counts.iter().sum::<u32>() as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
         p_value(&self.tags.to_tag_vec(), &self.counts, config).ok()
@@ -1969,7 +1796,6 @@ impl SummaryData<Tag> for TagsCountsEMData {
         Some(&self.edge_mults)
     }
 
-    fn quality(&self) -> Option<BaseQuality> { None }
 
     fn fix_edge_mults(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
@@ -1978,14 +1804,6 @@ impl SummaryData<Tag> for TagsCountsEMData {
     fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>) {
         self.edge_mults = edge_mults.expect("Error: no edge mults")
     }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
@@ -2104,8 +1922,6 @@ impl SummaryData<Tag> for TagsCountsPEMData{
         Some(self.counts.iter().sum::<u32>() as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
-
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
             Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
@@ -2126,8 +1942,6 @@ impl SummaryData<Tag> for TagsCountsPEMData{
         Some(&self.edge_mults)
     }
 
-    fn quality(&self) -> Option<BaseQuality> { None }
-
     fn fix_edge_mults(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
@@ -2135,14 +1949,6 @@ impl SummaryData<Tag> for TagsCountsPEMData{
     fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>) {
         self.edge_mults = edge_mults.expect("Error: no edge mults")
     }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
@@ -2284,8 +2090,6 @@ impl SummaryData<Tag> for TagsCountsPEMQualityData{
         Some(self.counts.iter().sum::<u32>() as usize)
     }
 
-    fn ids(&self) -> Option<&[ID]> { None }
-
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
             Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
@@ -2317,14 +2121,6 @@ impl SummaryData<Tag> for TagsCountsPEMQualityData{
     fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>) {
         self.edge_mults = edge_mults.expect("Error: no edge mults")
     }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
@@ -2467,26 +2263,6 @@ impl SummaryData<IDTag> for IDTagsCountsData {
 
     fn sample_count(&self) -> Option<usize> {
         Some(self.counts.len())
-    }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -2653,8 +2429,6 @@ impl SummaryData<IDTag> for IDTagsCountsPEMData{
         Some(&self.edge_mults)
     }
 
-    fn quality(&self) -> Option<BaseQuality> { None }
-
     fn fix_edge_mults(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
     }
@@ -2662,14 +2436,6 @@ impl SummaryData<IDTag> for IDTagsCountsPEMData{
     fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>) {
         self.edge_mults = edge_mults.expect("Error: no edge mults")
     }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.counts == other.counts
@@ -2739,29 +2505,17 @@ impl SummaryData<IDTag> for IDEMData{
         format!("\"ids\": {}", id_format(&self.ids, translator, id_group_translator)) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.ids)
     }
-
-    fn sum(&self) -> Option<usize> { None }
 
     fn ids(&self) -> Option<&[ID]> {
         Some(&self.ids)
     }
 
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
     fn edge_mults(&self) -> Option<&EdgeMult> {
         Some(&self.edge_mults)
     }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
 
     fn fix_edge_mults(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
@@ -2771,19 +2525,9 @@ impl SummaryData<IDTag> for IDEMData{
         self.edge_mults = edge_mults.expect("Error: no edge mults")
     }
 
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
     fn join_test(&self, other: &Self) -> bool {
         self.ids == other.ids
     }
-
-    fn valid(&self, _: &SummaryConfig) -> bool { true }
 
     fn summarize<K: Kmer, F: Iterator<Item = KmerDataItem<K, IDTag>>>(items: F, config: &SummaryConfig) -> (bool, Exts, Self) {
         let summary = summarize_tags_ids_edge_q(items, config);
@@ -2847,29 +2591,17 @@ impl SummaryData<IDTag> for IDMapEMData{
         format!("\"ids\": {ids_format}, \"mapped_ids\": {map_ids_format}, \"has_mapped_ids\": {has_mapped}", ) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.ids) + mem::size_of_val(&*self.map_ids)
     }
-
-    fn sum(&self) -> Option<usize> { None }
 
     fn ids(&self) -> Option<&[ID]> {
         Some(&self.ids)
     }
 
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
     fn edge_mults(&self) -> Option<&EdgeMult> {
         Some(&self.edge_mults)
     }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
 
     fn fix_edge_mults(&mut self, exts: Exts) {
         self.edge_mults.clean_edges(exts);
@@ -2887,16 +2619,10 @@ impl SummaryData<IDTag> for IDMapEMData{
         self.map_ids = mapped_ids
     }
 
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
     fn join_test(&self, other: &Self) -> bool {
         self.ids == other.ids 
         && self.map_ids == other.map_ids
     }
-
-    fn valid(&self, _: &SummaryConfig) -> bool { true }
 
     fn summarize<K: Kmer, F: Iterator<Item = KmerDataItem<K, IDTag>>>(items: F, config: &SummaryConfig) -> (bool, Exts, Self) {
         let summary = summarize_tags_ids_edge_q(items, config);
@@ -2963,23 +2689,13 @@ impl SummaryData<IDTag> for IDMapEMQualityData{
         format!("\"ids\": {ids_format}, \"mapped_ids\": {map_ids_format}, \"has_mapped_ids\": {has_mapped}, \"quality\": {}", self.quality as u8) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.ids) + mem::size_of_val(&*self.map_ids)
     }
 
-    fn sum(&self) -> Option<usize> { None }
-
     fn ids(&self) -> Option<&[ID]> {
         Some(&self.ids)
     }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
 
     fn edge_mults(&self) -> Option<&EdgeMult> {
         Some(&self.edge_mults)
@@ -3004,8 +2720,6 @@ impl SummaryData<IDTag> for IDMapEMQualityData{
     fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>) {
         self.map_ids = mapped_ids
     }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
 
     fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
@@ -3083,8 +2797,6 @@ impl SummaryData<Tag> for SumMapEMQualityData{
         format!("\"sum\": {}, \"mapped_ids\": {map_ids_format}, \"has_mapped_ids\": {has_mapped}, \"quality\": {}", self.sum, self.quality as u8) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.map_ids)
     }
@@ -3092,14 +2804,6 @@ impl SummaryData<Tag> for SumMapEMQualityData{
     fn sum(&self) -> Option<usize> { 
         Some(self.sum as usize)
     }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
 
     fn edge_mults(&self) -> Option<&EdgeMult> {
         Some(&self.edge_mults)
@@ -3124,10 +2828,6 @@ impl SummaryData<Tag> for SumMapEMQualityData{
     fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>) {
         self.map_ids = mapped_ids
     }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
 
     fn join_test(&self, other: &Self) -> bool {
         self.sum == other.sum 
@@ -3208,21 +2908,9 @@ impl SummaryData<Tag> for MapEMEmapQualityData{
         format!("\"mapped_ids_nodes\": {map_ids_format}, \"mapped_ids_edges\": \"{:?}\", \"has_mapped_ids\": {has_mapped}, \"quality\": {}", self.edge_maps, self.quality as u8) // rempve " to avoid conflicts in json file
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self) + mem::size_of_val(&*self.map_ids) + self.edge_maps.mem_heap()
     }
-
-    fn sum(&self) -> Option<usize> { None }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
 
     fn edge_mults(&self) -> Option<&EdgeMult> {
         Some(&self.edge_mults)
@@ -3316,42 +3004,12 @@ impl SummaryData<Tag> for GroupCountData {
         format!("\"count1\": {}, \"count2\": {}", self.group1, self.group2)
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self)
     }
 
     fn sum(&self) -> Option<usize> {
         Some((self.group1 + self.group2) as usize)
-    }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -3418,42 +3076,12 @@ impl SummaryData<Tag> for RelCountData {
         format!("\"rel_count_1\": {}, \"sum\": {}", self.percent, self.count)
     }
 
-    fn tags(&self) -> Option<Tags> { None }
-
     fn mem(&self) -> usize {
         mem::size_of_val(self)
     }
 
     fn sum(&self) -> Option<usize> {
         Some(self.count as usize)
-    }
-
-    fn ids(&self) -> Option<&[ID]> { None }
-
-    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
-
-    fn sample_count(&self) -> Option<usize> { None }
-
-    fn edge_mults(&self) -> Option<&EdgeMult> { None }
-
-    fn quality(&self) -> Option<BaseQuality> { None }
-
-    fn fix_edge_mults(&mut self, _: Exts) { }
-    
-    fn set_edge_mults(&mut self, _: Option<EdgeMult>) { }
-
-    fn mapped_ids(&self) -> Option<&[ID]> { None }
-
-    fn set_mapped_ids(&mut self, _: Box<[ID]>) { }
-
-    fn mapped_edge_ids(&self) -> Option<&EdgeMap> { None }
-
-    fn set_mapped_edge_ids(&mut self, _: EdgeMap) { }
-
-    fn join_test(&self, other: &Self) -> bool {
-        self == other
     }
     
     fn valid(&self, config: &SummaryConfig) -> bool {

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -3259,7 +3259,6 @@ impl SummaryData<Tag> for MapEMEmapQualityData{
     fn join_test(&self, other: &Self) -> bool {
         self.map_ids == other.map_ids
         && self.quality == other.quality
-        && self.edge_maps == other.edge_maps
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool { 

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -3090,6 +3090,120 @@ impl SummaryData<Tag> for SumMapEMQualityData{
     }
 }
 
+/// Implementation of [`SummaryData<Tag>`]
+/// 
+/// Contains the IDs the k-mer was observed with, a placeholder for mapped ids, and edge multiplicites/coverage
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MapEMQualityData {
+    map_ids: Box<[ID]>,
+    edge_mults: EdgeMult,
+    quality: BaseQuality
+}
+
+impl SummaryData<Tag> for MapEMQualityData{
+    fn print(&self, translator: &Translator, _: &SummaryConfig, id_group_translator: Option<&HashMap<ID, ID>>) -> String {
+        let map_ids_format = id_format(&self.map_ids, translator, id_group_translator);
+
+        format!("mapped IDs: {}, quality: {}, edge coverage: {}", 
+            map_ids_format,
+            self.quality,
+            self.edge_mults,
+        ).replace("\"", "\'") // replace " with ' to avoid conflicts in dot file
+    }
+
+    fn print_ol(&self, translator: &Translator, _: &SummaryConfig, id_group_translator: Option<&HashMap<ID, ID>>) -> String {
+        let map_ids_format = id_format(&self.map_ids, translator, id_group_translator);
+
+        format!("mapped IDs: {}, quality: {}, edge coverage: {:?}", 
+            map_ids_format,
+            self.quality,
+            self.edge_mults
+        ).replace("\"", "\'") // replace " with ' to avoid conflicts in dot file
+    }
+
+    fn print_json(&self, translator: &Translator, _: &SummaryConfig, id_group_translator: Option<&HashMap<ID, ID>>) -> String {
+        let map_ids_format = id_format(&self.map_ids, translator, id_group_translator);
+
+        let has_mapped = !self.map_ids.is_empty() as usize;
+
+        format!("\"mapped_ids\": {map_ids_format}, \"has_mapped_ids\": {has_mapped}, \"quality\": {}", self.quality as u8) // rempve " to avoid conflicts in json file
+    }
+
+    fn tags(&self) -> Option<Tags> { None }
+
+    fn mem(&self) -> usize {
+        mem::size_of_val(self) + mem::size_of_val(&*self.map_ids)
+    }
+
+    fn sum(&self) -> Option<usize> { None }
+
+    fn ids(&self) -> Option<&[ID]> { None }
+
+    fn p_value(&self, _: &SummaryConfig) -> Option<f32> { None }
+
+    fn fold_change(&self, _: &SummaryConfig) -> Option<f32> { None }
+
+    fn sample_count(&self) -> Option<usize> { None }
+
+    fn edge_mults(&self) -> Option<&EdgeMult> {
+        Some(&self.edge_mults)
+    }
+
+    fn quality(&self) -> Option<BaseQuality> {
+        Some(self.quality)
+    }
+
+    fn fix_edge_mults(&mut self, exts: Exts) {
+        self.edge_mults.clean_edges(exts);
+    }
+
+    fn set_edge_mults(&mut self, edge_mults: Option<EdgeMult>) {
+        self.edge_mults = edge_mults.expect("Error: no edge mults")
+    }
+
+    fn mapped_ids(&self) -> Option<&[ID]> {
+        Some(&self.map_ids)
+    }
+
+    fn set_mapped_ids(&mut self, mapped_ids: Box<[ID]>) {
+        self.map_ids = mapped_ids
+    }
+
+    fn join_test(&self, other: &Self) -> bool {
+        self.map_ids == other.map_ids
+        && self.quality == other.quality
+    }
+
+    fn valid(&self, config: &SummaryConfig) -> bool { 
+        self.quality >= config.min_quality
+    }
+
+    fn summarize<K: Kmer, F: Iterator<Item = KmerDataItem<K, Tag>>>(items: F, config: &SummaryConfig) -> (bool, Exts, Self) {
+        let summary = summarize_tags_edge_q(items, config);
+        
+        let quality = summary.highest_quality.expect("missing quality score - required for summarizer");
+        
+        // caluclate p-value with chosen test
+        let valid_p = valid_p(PInfo::Calculate { tag_vec: &summary.tag_vec, tag_counts: &summary.tag_counts}, config);
+        let valid_q = quality >= config.min_quality;
+
+        let tags = Tags::from_tag_vec(summary.tag_vec);
+
+        let valid = valid_counts(tags, Some(summary.sum), config) && valid_p && valid_q;
+
+        let sum = match config.significant {
+            Some(digits) => round_digits(summary.sum, digits),
+            None => summary.sum  
+        };
+
+        (valid, summary.all_exts, MapEMQualityData { map_ids: Vec::new().into(), edge_mults: summary.edge_mults, quality }) 
+    }
+
+    fn summarizer() -> Summarizers {
+        Summarizers::MapEMQuality
+    }
+}
+
 
 /// Implementation of [`SummaryData<Tag>`]
 /// 
@@ -3316,6 +3430,7 @@ pub enum Summarizers {
     IDMapEM,
     IDMapEMQuality,
     SumMapEMQuality,
+    MapEMQuality,
     GroupCount,
     RelCount
 }

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -187,6 +187,9 @@ impl Display for NotEnoughSamplesError {
 /// 
 /// // ...
 /// ```
+/// 
+/// By setting the `with_min_kmer_obs` to 0, k-mers for which all occurences were filtered
+/// out with `with_min_quality_for_edge`, can still be included, with empty k-mer data.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct SummaryConfig {
     min_kmer_obs: usize,
@@ -215,7 +218,7 @@ impl SummaryConfig {
     /// statistical analysis regarding sample groups.
     pub fn empty() -> Self {
         SummaryConfig { 
-            min_kmer_obs: 0, 
+            min_kmer_obs: 1, 
             significant: None, 
             group_frac: GroupFrac::None, 
             frac_cutoff: 0., 
@@ -478,7 +481,6 @@ struct TagSummary {
 /// summarize the k-mers, exts and labels, also include an [`EdgeMult`]
 fn summarize_tags<K: Kmer, F: Iterator<Item = KmerDataItem<K, Tag>>>(items: F) -> TagSummary {
     let mut all_exts = Exts::empty();
-
     let mut tag_vec: Vec<Tag> = Vec::with_capacity(items.size_hint().0);
     let mut edge_mults = EdgeMult::new();
     let mut highest_quality = None;
@@ -538,7 +540,6 @@ struct IDTagSummary {
 /// summarize the k-mers, exts and labels
 fn summarize_tags_ids<K: Kmer, F: Iterator<Item = KmerDataItem<K, IDTag>>>(items: F) -> IDTagSummary {
     let mut all_exts = Exts::empty();
-
     let mut tag_vec = Vec::with_capacity(items.size_hint().0);
     let mut id_vec = Vec::new();
     let mut edge_mults = EdgeMult::new();

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -512,26 +512,16 @@ fn summarize_tags<K: Kmer, F: Iterator<Item = KmerDataItem<K, Tag>>>(items: F) -
 
 fn summarize_tags_edge_q<K: Kmer, F: Iterator<Item = KmerDataItem<K, Tag>>>(items: F, config: &SummaryConfig) 
 -> TagSummary
-{
-    // collect items so they can be used twice
-    let collected_items = items.collect::<Vec<_>>();
-    
+{    
     // filter the k-mer occurences by their quality -> only use exts and data from k-mers with good enough quality
-    let items_filtered = collected_items.iter().copied().filter(|item| 
+    let items_filtered = items.filter(|item| 
         match item.quality {
             None => true,
             Some(q) => q >= config.min_quality_for_edge
         }
     );
-    let summary = summarize_tags(items_filtered);
     
-    // if there are no exts in one or both directions, repeat without filter so low coverage connections are not lost
-    if (summary.all_exts.num_exts_l() == 0) | (summary.all_exts.num_exts_r() == 0) {
-        // filter the k-mer occurences by their quality -> only use exts and data from k-mers with good enough quality
-        summarize_tags(collected_items.into_iter())
-    } else {
-        summary
-    }
+    summarize_tags(items_filtered)
 }
 
 #[derive(Debug)]
@@ -586,25 +576,15 @@ fn summarize_tags_ids<K: Kmer, F: Iterator<Item = KmerDataItem<K, IDTag>>>(items
 fn summarize_tags_ids_edge_q<K: Kmer, F: Iterator<Item = KmerDataItem<K, IDTag>>>(items: F, config: &SummaryConfig) 
 -> IDTagSummary
 {
-    // collect items so they can be used twice
-    let collected_items = items.collect::<Vec<_>>();
-    
     // filter the k-mer occurences by their quality -> only use exts and data from k-mers with good enough quality
-    let items_filtered = collected_items.iter().copied().filter(|item|
+    let items_filtered = items.filter(|item|
         match item.quality {
             None => true,
             Some(q) => q >= config.min_quality_for_edge
         }
     );
-    let summary = summarize_tags_ids(items_filtered);
-    
-    // if there are no exts in one or both directions, repeat without filter so low coverage connections are not lost
-    if (summary.all_exts.num_exts_l() == 0) | (summary.all_exts.num_exts_r() == 0) {
-        // filter the k-mer occurences by their quality -> only use exts and data from k-mers with good enough quality
-        summarize_tags_ids(collected_items.into_iter())
-    } else {
-        summary
-    }
+
+    summarize_tags_ids(items_filtered)
 }
 
 /// round an unsigned integer to the specified amount of digits,
@@ -679,7 +659,7 @@ fn valid_p(p_info: PInfo, config: &SummaryConfig) -> bool {
     }
 }
 
-fn p_value(tag_vec: &[Tag], tag_counts: &Vec<u32>, config: &SummaryConfig) -> Result<f32, NotEnoughSamplesError> {
+fn p_value(tag_vec: &[Tag], tag_counts: &[u32], config: &SummaryConfig) -> Result<f32, NotEnoughSamplesError> {
     match config.stat_test {
         StatTest::StudentsTTest => students_t_test(tag_vec, tag_counts, &config.sample_info),
         StatTest::WelchsTTest => welchs_t_test(tag_vec, tag_counts, &config.sample_info),
@@ -688,7 +668,7 @@ fn p_value(tag_vec: &[Tag], tag_counts: &Vec<u32>, config: &SummaryConfig) -> Re
 }
 
 // perform a student's t-test
-fn students_t_test(tag_vec: &[Tag], tag_counts: &Vec<u32>, sample_info: &SampleInfo) -> Result<f32, NotEnoughSamplesError> {
+fn students_t_test(tag_vec: &[Tag], tag_counts: &[u32], sample_info: &SampleInfo) -> Result<f32, NotEnoughSamplesError> {
     let n0 = sample_info.count0 as f64;
     let n1 = sample_info.count1 as f64;
 
@@ -726,7 +706,7 @@ fn students_t_test(tag_vec: &[Tag], tag_counts: &Vec<u32>, sample_info: &SampleI
 }
 
 // perform a welch's t-test
-fn welchs_t_test(tag_vec: &[Tag], tag_counts: &Vec<u32>, sample_info: &SampleInfo) -> Result<f32, NotEnoughSamplesError> {
+fn welchs_t_test(tag_vec: &[Tag], tag_counts: &[u32], sample_info: &SampleInfo) -> Result<f32, NotEnoughSamplesError> {
     let n0 = sample_info.count0 as f64;
     let n1 = sample_info.count1 as f64;
 
@@ -770,7 +750,7 @@ fn welchs_t_test(tag_vec: &[Tag], tag_counts: &Vec<u32>, sample_info: &SampleInf
 }
 
 // perform a mann-whitney-u-test
-fn u_test(tag_vec: &[Tag], tag_counts: &Vec<u32>, sample_info: &SampleInfo) -> Result<f32, NotEnoughSamplesError> {
+fn u_test(tag_vec: &[Tag], tag_counts: &[u32], sample_info: &SampleInfo) -> Result<f32, NotEnoughSamplesError> {
 
     let n0 = sample_info.count0 as f64;
     let n1 = sample_info.count1 as f64;
@@ -843,13 +823,13 @@ fn u_test(tag_vec: &[Tag], tag_counts: &Vec<u32>, sample_info: &SampleInfo) -> R
 }
 
 // calculate the log2 of the log change of the two groups
-fn log2_fold_change(tags: Tags, counts: Vec<u32>, sample_info: &SampleInfo) -> f32 {
+fn log2_fold_change(tags: Tags, counts: &[u32], sample_info: &SampleInfo) -> f32 {
     let mut norm_count_g0 = 0.;
     let mut norm_count_g1 = 0.;
 
     let (m0, m1) = sample_info.get_markers();
 
-    for (label, count) in tags.to_tag_vec().iter().zip(&counts) {
+    for (label, count) in tags.to_tag_vec().iter().zip(counts) {
         let bin_rep = (2 as Marker).pow(*label as u32);
         // normalize with number of k-mers in the sample
         let norm = *count as f64 / sample_info.sample_kmers[*label as usize] as f64;
@@ -1523,12 +1503,12 @@ impl SummaryData<Tag> for TagsCountsSumData {
     }
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
-        p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).ok()
+        p_value(&self.tags.to_tag_vec(), &self.counts, config).ok()
     }
 
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn valid(&self, config: &SummaryConfig) -> bool {
@@ -1649,12 +1629,12 @@ impl SummaryData<Tag> for TagsCountsData {
     fn ids(&self) -> Option<&[ID]> { None }
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
-        p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).ok()
+        p_value(&self.tags.to_tag_vec(), &self.counts, config).ok()
     }
 
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn sample_count(&self) -> Option<usize> {
@@ -1792,14 +1772,14 @@ impl SummaryData<Tag> for TagsCountsPData {
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
-            Some(p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).unwrap())
+            Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
         } else {
             Some(self.p_value)
         } 
     }
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
     
     fn sample_count(&self) -> Option<usize> {
@@ -1934,11 +1914,11 @@ impl SummaryData<Tag> for TagsCountsEMData {
     fn ids(&self) -> Option<&[ID]> { None }
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
-        p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).ok()
+        p_value(&self.tags.to_tag_vec(), &self.counts, config).ok()
     }
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn sample_count(&self) -> Option<usize> {
@@ -2084,14 +2064,14 @@ impl SummaryData<Tag> for TagsCountsPEMData{
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
-            Some(p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).unwrap())
+            Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
         } else {
             Some(self.p_value)
         } 
     }
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn sample_count(&self) -> Option<usize> {
@@ -2260,14 +2240,14 @@ impl SummaryData<Tag> for TagsCountsPEMQualityData{
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
-            Some(p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).unwrap())
+            Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
         } else {
             Some(self.p_value)
         } 
     }
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn sample_count(&self) -> Option<usize> {
@@ -2425,12 +2405,12 @@ impl SummaryData<IDTag> for IDTagsCountsData {
     }
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {      
-        p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).ok()
+        p_value(&self.tags.to_tag_vec(), &self.counts, config).ok()
     }
 
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn sample_count(&self) -> Option<usize> {
@@ -2599,14 +2579,14 @@ impl SummaryData<IDTag> for IDTagsCountsPEMData{
 
     fn p_value(&self, config: &SummaryConfig) -> Option<f32> {
         if config.stat_test_changed {
-            Some(p_value(&self.tags.to_tag_vec(), &self.counts.to_vec(), config).unwrap())
+            Some(p_value(&self.tags.to_tag_vec(), &self.counts, config).unwrap())
         } else {
             Some(self.p_value)
         } 
     }
 
     fn fold_change(&self, config: &SummaryConfig) -> Option<f32> {
-        Some(log2_fold_change(self.tags, self.counts.to_vec(), &config.sample_info))
+        Some(log2_fold_change(self.tags, &self.counts, &config.sample_info))
     }
 
     fn sample_count(&self) -> Option<usize> {
@@ -3521,27 +3501,27 @@ mod test {
         let labels = vec![0, 1, 2, 3, 7, 8];
         let tags = Tags::from_tag_vec(labels);
         let counts = vec![1, 6, 9, 3, 6, 10];
-        let fold_change = log2_fold_change(tags, counts, &sample_info);
+        let fold_change = log2_fold_change(tags, &counts, &sample_info);
         assert_eq!(fold_change, 5.286_453_2);
 
         let labels = vec![0, 6, 7, 8, 10, 11];
         let tags = Tags::from_tag_vec(labels);
         let counts = vec![12, 3, 7, 1, 22, 6];
-        let fold_change = log2_fold_change(tags, counts, &sample_info);
+        let fold_change = log2_fold_change(tags, &counts, &sample_info);
         assert_eq!(fold_change, -1.339_324_5);
 
         // x/0 = inf -> log(inf) = inf
         let labels = vec![0, 1];
         let tags = Tags::from_tag_vec(labels);
         let counts = vec![12, 3];
-        let fold_change = log2_fold_change(tags, counts, &sample_info);
+        let fold_change = log2_fold_change(tags, &counts, &sample_info);
         assert_eq!(fold_change, f32::INFINITY);
 
         // 0/x = 0 -> log2(0) = -inf
         let labels = vec![7, 8];
         let tags = Tags::from_tag_vec(labels);
         let counts = vec![12, 3];
-        let fold_change = log2_fold_change(tags, counts, &sample_info);
+        let fold_change = log2_fold_change(tags, &counts, &sample_info);
         assert_eq!(fold_change, f32::NEG_INFINITY);       
     }
 

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -3609,7 +3609,7 @@ mod test {
         let (kmers, _) = filter_kmers::<TagsData, Kmer16, _>(&reads_paired, &summary_config, false, 1., false);
 
         let comp_spec = CheckCompress::new(|a: TagsData, _b| a, |a, b| a.join_test(b));
-        let mut graph = compress_kmers_with_hash(true, &comp_spec, &kmers, false, false).finish();
+        let mut graph = compress_kmers_with_hash(true, &comp_spec, kmers, false, false).finish();
         graph.fix_exts(None);
 
         for node_id in 0..graph.len() {
@@ -3635,7 +3635,7 @@ mod test {
         let (kmers, _) = filter_kmers::<IDData, Kmer16, _>(&reads_paired, &summary_config, false, 1., false);
 
         let comp_spec = CheckCompress::new(|a: IDData, _b| a, |a, b| a.join_test(b));
-        let mut graph = compress_kmers_with_hash(true, &comp_spec, &kmers, false, false).finish();
+        let mut graph = compress_kmers_with_hash(true, &comp_spec, kmers, false, false).finish();
         graph.fix_exts(None);
 
         for node_id in 0..graph.len() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -781,7 +781,7 @@ mod tests {
 
         let mut graph = graph.finish();
         graph.fix_exts(None);
-        graph.fix_edge_mults();
+        graph.fix_edge_data();
         let _ = graph.filter_edges(2);
         graph.print();
         /* graph.to_dot("test_out", &|d| format!("{:?}", d));

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,8 +9,6 @@ use crate::compression::CheckCompress;
 use crate::compression::compress_kmers_with_hash;
 use crate::dna_string::DnaString;
 use crate::filter::filter_kmers;
-use crate::graph::BaseGraph;
-use crate::graph::DebruijnGraph;
 use crate::reads::ReadData;
 use crate::reads::Reads;
 use crate::reads::ReadsPaired;
@@ -18,7 +16,6 @@ use crate::serde::SerGraph;
 use crate::serde::SerKmers;
 use crate::serde::SerReads;
 use crate::summarizer::ID;
-use crate::summarizer::IDTag;
 use crate::summarizer::SampleInfo;
 use crate::summarizer::SummaryConfig;
 use crate::summarizer::SummaryData;
@@ -275,7 +272,7 @@ where
     let ser_kmers = SerKmers::new(kmers.clone(), translator.clone(), summary_config.clone());
 
     let comp_spec = CheckCompress::new(|d: SD, _| d, |d, d1| d.join_test(d1));
-    let graph = compress_kmers_with_hash(true, &comp_spec, &kmers, false, false).finish();
+    let graph = compress_kmers_with_hash(true, &comp_spec, kmers, false, false).finish();
     let ser_graph = SerGraph::new(graph, translator, summary_config);
 
     (ser_reads, ser_kmers, ser_graph)
@@ -408,7 +405,7 @@ mod tests {
 
         let spec =
             SimpleCompress::new(|d1: u32, d2: &u32| (d1 + *d2) % 65535);
-        let from_kmers = compress_kmers_with_hash::<K, u32, _, _>(stranded, &spec, &valid_kmers, true, false).finish();
+        let from_kmers = compress_kmers_with_hash::<K, u32, _, _>(stranded, &spec, valid_kmers.clone(), true, false).finish();
         let is_cmp = from_kmers.is_compressed(&spec);
         if is_cmp.is_some() {
             println!("not compressed: nodes: {:?}", is_cmp);
@@ -432,8 +429,10 @@ mod tests {
         }
         let uncompressed_dbg = base_graph.finish();
 
+        let total_kmers = valid_kmers.len();
+        
         // comparison uncompressed graph
-        let uc_graph = uncompressed_graph(&valid_kmers, false).finish_serial();
+        let uc_graph = uncompressed_graph(valid_kmers, false).finish_serial();
         assert_eq!(uc_graph.base.sequences.sequence, uncompressed_dbg.base.sequences.sequence);
 
         // remove nodes from uncompressed graph
@@ -453,13 +452,11 @@ mod tests {
 
         assert!(simp_dbg.is_compressed(&spec).is_none());
 
-        let total_kmers = valid_kmers.len();
-
         // Test the Boomphf DBG indexing machinery
         // Make an MPHF of the kmers in the DBG.
         // Each kmer should hash to a unique slot.
         let mphf =
-            Mphf::from_chunked_iterator_parallel(1.7, &simp_dbg, None, valid_kmers.len() as u64, 2);
+            Mphf::from_chunked_iterator_parallel(1.7, &simp_dbg, None, total_kmers as u64, 2);
 
         let mut got_slot = vec![false; total_kmers];
 
@@ -561,7 +558,7 @@ mod tests {
         let spec = SimpleCompress::new(|d1: u32, d2: &u32| d1.saturating_add(*d2));
 
         // Generate compress DBG for these kmers
-        let graph = compress_kmers_with_hash::<K, u32, u8, _>(stranded, &spec, &valid_kmers, true, false);
+        let graph = compress_kmers_with_hash::<K, u32, u8, _>(stranded, &spec, valid_kmers, true, false);
 
         // Check that all the lines have valid kmers,
         // and have extensions into other valid kmers
@@ -642,7 +639,7 @@ mod tests {
             let spec = SimpleCompress::new(|d1: u32, d2: &u32| d1.saturating_add(*d2));
 
             //print!("{:?}", valid_kmers);
-            let graph = compress_kmers_with_hash::<K, u32, u8, _>(stranded, &spec, &valid_kmers, true, false);
+            let graph = compress_kmers_with_hash::<K, u32, u8, _>(stranded, &spec, valid_kmers, true, false);
             shard_asms.push(graph.clone());
             //graph.finish().print();
         }
@@ -734,7 +731,7 @@ mod tests {
             true,
         );
         let spec = SimpleCompress::new(|d1: u32, d2: &u32| d1 + d2);
-        let graph = compress_kmers_with_hash::<K, u32, u8, _>(stranded, &spec, &valid_kmers_clean, true, false);
+        let graph = compress_kmers_with_hash::<K, u32, u8, _>(stranded, &spec, valid_kmers_clean, true, false);
         let graph1 = graph.finish();
         graph1.print();
         println!("components: {:?}", graph1.components_r());
@@ -779,7 +776,7 @@ mod tests {
 
         //let spec = SimpleCompress::new(|d1: u16, d2: &u16| d1 + d2);
         let spec = ScmapCompress::new();
-        let graph = compress_kmers_with_hash(stranded, &spec, &valid_kmers_errs, true, true);
+        let graph = compress_kmers_with_hash(stranded, &spec, valid_kmers_errs, true, true);
         println!("graph: {:?}", graph);
 
         let mut graph = graph.finish();

--- a/tests/test_colors.rs
+++ b/tests/test_colors.rs
@@ -174,7 +174,7 @@ fn test_colors_mapped_ids() {
     let sample_info = SampleInfo::new(0b1, 0b0, vec![2]);
     let summary_config = SummaryConfig::new(sample_info);
     let (kmers, _) = filter_kmers::<IDMapEMData, Kmer8, _>(&reads, &summary_config, false, 1., false);
-    let mut graph = uncompressed_graph(&kmers, true).finish();
+    let mut graph = uncompressed_graph(kmers, true).finish();
 
     graph.print();
 

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -2,7 +2,7 @@
 use std::mem;
 
 use bimap::BiHashMap;
-use debruijn::{BaseQuality, EdgeMult, Exts, Kmer, KmerDataItem, Tags, kmer::Kmer8, reads::ReadData, summarizer::{GroupCountData, GroupFrac, ID, IDData, IDEMData, IDMapEMData, IDMapEMQualityData, IDSumData, IDTagsCountsData, IDTagsCountsPEMData, RelCountData, SampleInfo, SumMapEMQualityData, Summarizers, SummaryConfig, SummaryData, Tag, TagsCountsData, TagsCountsEMData, TagsCountsPData, TagsCountsPEMData, TagsCountsPEMQualityData, TagsCountsSumData, TagsData, TagsSumData, Translator}};
+use debruijn::{BaseQuality, EdgeMult, Exts, Kmer, KmerDataItem, Tags, kmer::Kmer8, reads::ReadData, summarizer::{GroupCountData, GroupFrac, ID, IDData, IDEMData, IDMapEMData, IDMapEMQualityData, IDSumData, IDTagsCountsData, IDTagsCountsPEMData, MapEMQualityData, RelCountData, SampleInfo, SumMapEMQualityData, Summarizers, SummaryConfig, SummaryData, Tag, TagsCountsData, TagsCountsEMData, TagsCountsPData, TagsCountsPEMData, TagsCountsPEMQualityData, TagsCountsSumData, TagsData, TagsSumData, Translator}};
 
 #[derive(Debug, PartialEq)]
 struct SummaryTest {
@@ -555,6 +555,29 @@ fn test_summary_data() {
         mapped_ids:  mapped_ids.clone(),
         valid,
         summarizer: Summarizers::SumMapEMQuality,
+    };
+
+    assert_eq!(test_data, compare_data);
+
+    // MapEMQualityData
+
+    let test_data = test_summarize::<MapEMQualityData, Kmer8, _, _>(input_tags.into_iter(), &config, &translator);
+    let compare_data = SummaryTest {
+        print: "mapped IDs: ['1', '2', '3'], quality: medium, edge coverage: A: 1 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        print_ol: "mapped IDs: ['1', '2', '3'], quality: medium, edge coverage: A: 1, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string(),
+        print_json: "\"mapped_ids\": [\"1\", \"2\", \"3\"], \"has_mapped_ids\": 1, \"quality\": 2".to_string(),
+        tags: None,
+        mem: size_aligned(mi_m_s + em_m + q_m, mi_m_h, 8),
+        sum: None,
+        ids:  None,
+        p_value: None,
+        fold_change: None,
+        sample_count: None,
+        edge_mults:  edge_mults.clone(),
+        quality,
+        mapped_ids:  mapped_ids.clone(),
+        valid,
+        summarizer: Summarizers::MapEMQuality,
     };
 
     assert_eq!(test_data, compare_data);

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -2,7 +2,7 @@
 use std::mem;
 
 use bimap::BiHashMap;
-use debruijn::{BaseQuality, EdgeMult, Exts, Kmer, KmerDataItem, Tags, kmer::Kmer8, reads::ReadData, summarizer::{GroupCountData, GroupFrac, ID, IDData, IDEMData, IDMapEMData, IDMapEMQualityData, IDSumData, IDTagsCountsData, IDTagsCountsPEMData, MapEMQualityData, RelCountData, SampleInfo, SumMapEMQualityData, Summarizers, SummaryConfig, SummaryData, Tag, TagsCountsData, TagsCountsEMData, TagsCountsPData, TagsCountsPEMData, TagsCountsPEMQualityData, TagsCountsSumData, TagsData, TagsSumData, Translator}};
+use debruijn::{BaseQuality, EdgeMap, EdgeMult, Exts, Kmer, KmerDataItem, Tags, kmer::Kmer8, reads::ReadData, summarizer::{GroupCountData, GroupFrac, ID, IDData, IDEMData, IDMapEMData, IDMapEMQualityData, IDSumData, IDTagsCountsData, IDTagsCountsPEMData, MapEMEmapQualityData, RelCountData, SampleInfo, SumMapEMQualityData, Summarizers, SummaryConfig, SummaryData, Tag, TagsCountsData, TagsCountsEMData, TagsCountsPData, TagsCountsPEMData, TagsCountsPEMQualityData, TagsCountsSumData, TagsData, TagsSumData, Translator}};
 
 #[derive(Debug, PartialEq)]
 struct SummaryTest {
@@ -19,6 +19,7 @@ struct SummaryTest {
     edge_mults: Option<EdgeMult>,
     quality: Option<BaseQuality>,
     mapped_ids: Option<Vec<ID>>, // also include set_ma
+    mapped_edge_ids: Option<EdgeMap>,
     valid: bool,
     summarizer: Summarizers
 }
@@ -62,6 +63,18 @@ where
     let mapped_ids = data.mapped_ids().map(|m| m.into());
     let ids = data.ids().map(|ids| ids.to_vec());
 
+    let mut emap = EdgeMap::default();
+    emap.add_id(Exts { val: 0b0101010 }, 1);
+    emap.add_id(Exts { val: 0b0010010 }, 2);
+    emap.add_id(Exts { val: 0b0100011 }, 3);
+
+    data.set_mapped_edge_ids(emap.clone());
+    if let Some(m) = data.mapped_edge_ids() {
+        assert_eq!(m, &emap)
+    }
+
+    let mapped_edge_ids = data.mapped_edge_ids().cloned();
+
     SummaryTest { 
         print: data.print(translator, config, None),
         print_ol: data.print_ol(translator, config, None), 
@@ -76,6 +89,7 @@ where
         edge_mults:  edge_mults.clone(), 
         quality: data.quality(), 
         mapped_ids, 
+        mapped_edge_ids,
         valid, 
         summarizer: SD::summarizer() 
     }
@@ -132,13 +146,21 @@ fn test_summary_data() {
     let edge_mults = Some(EdgeMult::new_from([0, 0, 0, 0, 0, 0, 0, 6]));
     let em_m = 8 * 4; // EdgeMult
 
-
     let ids = Some(vec![0, 1, 2, 3, 7, 8]);
     let i_m_s = 16; // Boxed slice
     let i_m_h = 6 * mem::size_of::<ID>(); // ids, depend on feature
     let mapped_ids = Some(vec![1, 2, 3]);
     let mi_m_s = 16; // Boxed slice
     let mi_m_h = 3 * mem::size_of::<ID>(); // ids, depend on feature
+
+    let mut emap = EdgeMap::default();
+    emap.add_id(Exts { val: 0b0101010 }, 1);
+    emap.add_id(Exts { val: 0b0010010 }, 2);
+    emap.add_id(Exts { val: 0b0100011 }, 3);
+
+    let emap_m_s = 128;
+    let emap_m_h = emap.mem_heap();
+    let mapped_edge_ids = Some(emap);
 
     let quality = Some(BaseQuality::Medium);
     let q_m = 1; // BaseQuality (enum -> u8)
@@ -162,6 +184,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::Sum,
     };
@@ -185,6 +208,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::VecTags,
     };
@@ -208,6 +232,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::ID,
     };
@@ -231,6 +256,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::IDSum,
     };
@@ -254,6 +280,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::Tags,
     };
@@ -277,6 +304,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsSum,
     };
@@ -300,6 +328,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsCountsSum,
     };
@@ -323,6 +352,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsCounts,
     };
@@ -346,6 +376,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsCountsP,
     };
@@ -369,6 +400,7 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsCountsEM,
     };
@@ -392,6 +424,7 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsCountsPEM,
     };
@@ -415,6 +448,7 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::TagsCountsPEMQuality,
     };
@@ -438,6 +472,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::IDTagsCounts,
     };
@@ -461,6 +496,7 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::IDTagsCountsPEM,
     };
@@ -484,6 +520,7 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::IDEM,
     };
@@ -507,6 +544,7 @@ fn test_summary_data() {
         edge_mults: edge_mults.clone(),
         quality: None,
         mapped_ids: mapped_ids.clone(),
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::IDMapEM,
     };
@@ -530,6 +568,7 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality,
         mapped_ids:  mapped_ids.clone(),
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::IDMapEMQuality,
     };
@@ -553,21 +592,22 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality,
         mapped_ids:  mapped_ids.clone(),
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::SumMapEMQuality,
     };
 
     assert_eq!(test_data, compare_data);
 
-    // MapEMQualityData
+    // MapEMEmapQualityData
 
-    let test_data = test_summarize::<MapEMQualityData, Kmer8, _, _>(input_tags.into_iter(), &config, &translator);
+    let test_data = test_summarize::<MapEMEmapQualityData, Kmer8, _, _>(input_tags.into_iter(), &config, &translator);
     let compare_data = SummaryTest {
         print: "mapped IDs: ['1', '2', '3'], quality: medium, edge coverage: A: 1 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
         print_ol: "mapped IDs: ['1', '2', '3'], quality: medium, edge coverage: A: 1, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string(),
         print_json: "\"mapped_ids\": [\"1\", \"2\", \"3\"], \"has_mapped_ids\": 1, \"quality\": 2".to_string(),
         tags: None,
-        mem: size_aligned(mi_m_s + em_m + q_m, mi_m_h, 8),
+        mem: size_aligned(mi_m_s + em_m + q_m + emap_m_s, mi_m_h + emap_m_h, 8),
         sum: None,
         ids:  None,
         p_value: None,
@@ -576,8 +616,9 @@ fn test_summary_data() {
         edge_mults:  edge_mults.clone(),
         quality,
         mapped_ids:  mapped_ids.clone(),
+        mapped_edge_ids,
         valid,
-        summarizer: Summarizers::MapEMQuality,
+        summarizer: Summarizers::MapEMEmapQuality,
     };
 
     assert_eq!(test_data, compare_data);
@@ -599,6 +640,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::GroupCount,
     };
@@ -622,6 +664,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::RelCount,
     };
@@ -650,6 +693,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid,
         summarizer: Summarizers::Tags,
     };
@@ -674,6 +718,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid: false,
         summarizer: Summarizers::Tags,
     };
@@ -698,6 +743,7 @@ fn test_summary_data() {
         edge_mults: None,
         quality: None,
         mapped_ids: None,
+        mapped_edge_ids: None,
         valid: false,
         summarizer: Summarizers::Tags,
     };

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -2,7 +2,7 @@
 use std::mem;
 
 use bimap::BiHashMap;
-use debruijn::{BaseQuality, EdgeMap, EdgeMult, Exts, Kmer, KmerDataItem, Tags, kmer::Kmer8, reads::ReadData, summarizer::{GroupCountData, GroupFrac, ID, IDData, IDEMData, IDMapEMData, IDMapEMQualityData, IDSumData, IDTagsCountsData, IDTagsCountsPEMData, MapEMEmapQualityData, RelCountData, SampleInfo, SumMapEMQualityData, Summarizers, SummaryConfig, SummaryData, Tag, TagsCountsData, TagsCountsEMData, TagsCountsPData, TagsCountsPEMData, TagsCountsPEMQualityData, TagsCountsSumData, TagsData, TagsSumData, Translator}};
+use debruijn::{BaseQuality, EdgeMap, EdgeMult, Exts, Kmer, KmerDataItem, Tags, kmer::Kmer8, reads::ReadData, size_aligned, summarizer::{GroupCountData, GroupFrac, ID, IDData, IDEMData, IDMapEMData, IDMapEMQualityData, IDSumData, IDTagsCountsData, IDTagsCountsPEMData, MapEMEmapQualityData, RelCountData, SampleInfo, SumMapEMQualityData, Summarizers, SummaryConfig, SummaryData, Tag, TagsCountsData, TagsCountsEMData, TagsCountsPData, TagsCountsPEMData, TagsCountsPEMQualityData, TagsCountsSumData, TagsData, TagsSumData, Translator}};
 
 #[derive(Debug, PartialEq)]
 struct SummaryTest {
@@ -749,16 +749,4 @@ fn test_summary_data() {
     };
 
     assert_eq!(test_data, compare_data);
-}
-
-/// add the alignment buffer to a structure
-/// - `size_heap`: contents of boxes/vectors -> are stored separately and do not go into alignment calculation
-fn size_aligned(size_stack: usize, size_heap: usize, align: usize) -> usize {
-    let empty = size_stack % align;
-    let buffer = match empty {
-        0 => 0,
-        _ => align - empty
-    };
-
-    buffer + size_heap + size_stack
 }

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -43,7 +43,7 @@ where
 
     let edge_mults = data.edge_mults().cloned();
 
-    data.fix_edge_mults(Exts::new(0));
+    data.fix_edge_data(Exts::new(0));
     if let Some(e) = data.edge_mults() {
         assert_eq!(e.edge_mults(), [0; 8]);
     }

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -68,7 +68,7 @@ where
     emap.add_id(Exts { val: 0b0010010 }, 2);
     emap.add_id(Exts { val: 0b0100011 }, 3);
 
-    data.set_mapped_edge_ids(emap.clone());
+    data.set_mapped_edge_ids(Some(emap.clone()));
     if let Some(m) = data.mapped_edge_ids() {
         assert_eq!(m, &emap)
     }

--- a/tests/test_summarizer.rs
+++ b/tests/test_summarizer.rs
@@ -603,9 +603,9 @@ fn test_summary_data() {
 
     let test_data = test_summarize::<MapEMEmapQualityData, Kmer8, _, _>(input_tags.into_iter(), &config, &translator);
     let compare_data = SummaryTest {
-        print: "mapped IDs: ['1', '2', '3'], quality: medium, edge coverage: A: 1 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
-        print_ol: "mapped IDs: ['1', '2', '3'], quality: medium, edge coverage: A: 1, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string(),
-        print_json: "\"mapped_ids\": [\"1\", \"2\", \"3\"], \"has_mapped_ids\": 1, \"quality\": 2".to_string(),
+        print: "mapped IDs (node): ['1', '2', '3'], mapped IDs (edges): A: [3] | [2]\nC: [1, 2, 3] | [1, 3]\nG: [] | []\nT: [1] | []\n, quality: medium, edge coverage: A: 1 | 0\nC: 0 | 0\nG: 0 | 0\nT: 0 | 0\n".to_string(), 
+        print_ol: "mapped IDs (node): ['1', '2', '3'], mapped IDs (edges): A: [3], C: [1, 2, 3], G: [], T: [1] | A: [2], C: [1, 3], G: [], T: [], quality: medium, edge coverage: A: 1, C: 0, G: 0, T: 0 | A: 0, C: 0, G: 0, T: 0".to_string(),
+        print_json: "\"mapped_ids_nodes\": [\"1\", \"2\", \"3\"], \"mapped_ids_edges\": \"A: [3], C: [1, 2, 3], G: [], T: [1] | A: [2], C: [1, 3], G: [], T: []\", \"has_mapped_ids\": 1, \"quality\": 2".to_string(),
         tags: None,
         mem: size_aligned(mi_m_s + em_m + q_m + emap_m_s, mi_m_h + emap_m_h, 8),
         sum: None,


### PR DESCRIPTION
- increase memory efficiency of `BaseGraph`
- remove disconnection check in k-mer quality edge filter during graph construction
    - the filter now excludes all k-mer occurrences with a low quality, even if this removes the k-mer from the graph or disconnects it on one side
 -  implement default methods in `SummaryData` and remove them from the trait implementations
 - add `DebruinGraph::map_transcripts_to_edges` which maps sequences from a FASTA reference to the edges of a graph instead of the nodes
 - add `DebruijnGraph::remove_lc_paths` which works similar to `remove_lq_paths` but uses the edge coverage instead of the node quality
 - adapt error removal and reference mapping algorithms to be able to handle unstranded graphs